### PR TITLE
Update algorithm to FSRS 4.5

### DIFF
--- a/Tests/FSRSTests/FSRSTests.swift
+++ b/Tests/FSRSTests/FSRSTests.swift
@@ -17,17 +17,20 @@ final class FSRSTests: XCTestCase {
         XCTAssertEqual(card.status, .new)
 
         f.p.w = [
-            1.14, 1.01, 5.44, 14.67, 5.3024, 1.5662, 1.2503, 0.0028,
-            1.5489, 0.1763, 0.9953, 2.7473, 0.0179, 0.3105, 0.3976, 0.0, 2.0902
+            1.0171, 1.8296, 4.4145, 10.9355, 5.0965, 1.3322, 1.017, 0.0, 1.6243, 0.1369, 1.0321,
+            2.1866, 0.0661, 0.336, 1.7766, 0.1693, 2.9244
         ]
         
-    //        let now = DateComponents(calendar: .current, year: 2022, month: 9, day: 29, hour: 12, minute: 30, second: 0).date!
-        let now = Date(timeIntervalSince1970: 1669721400)
+        // Tue Nov 29 2022 12:30:00 UTC+0000
+        let now = Date(timeIntervalSince1970: 1669681800)
         var schedulingCards = f.repeat(card: card, now: now)
         
         print(schedulingCards)
         
-        let ratings: [Rating] = [.good, .good, .good, .good, .good, .good, .again, .again, .good, .good, .good, .good, .good, .hard, .easy, .good]
+        let ratings: [Rating] = [
+            .good, .good, .good, .good, .good, .good, .again,
+            .again, .good, .good, .good, .good, .good
+        ]
         var ivlHistory: [Double] = []
         var statusHistory: [Status] = []
         
@@ -48,9 +51,43 @@ final class FSRSTests: XCTestCase {
         print(ivlHistory)
         print(statusHistory)
         
-        XCTAssertEqual(ivlHistory, [0, 5, 16, 43, 106, 236, 0, 0, 12, 25, 47, 85, 147, 147, 351, 551])
-        XCTAssertEqual(statusHistory, [.new, .learning, .review, .review, .review, .review, .review, .relearning, .relearning, .review, .review, .review, .review, .review, .review, .review])
-
+        XCTAssertEqual(ivlHistory, [0, 4, 15, 49, 143, 379, 0, 0, 15, 37, 85, 184, 376])
+        XCTAssertEqual(statusHistory, [
+            .new, .learning, .review, .review, .review, .review, .review,
+            .relearning, .relearning, .review, .review, .review, .review
+        ])
+    }
+    
+    func testMemoState() throws {
+        var f = FSRS()
+        var card = Card()
+        
+        f.p.w = [
+            1.0171, 1.8296, 4.4145, 10.9355, 5.0965, 1.3322, 1.017, 0.0, 1.6243, 0.1369, 1.0321,
+            2.1866, 0.0661, 0.336, 1.7766, 0.1693, 2.9244
+        ]
+        
+        // Tue Nov 29 2022 12:30:00 UTC+0000
+        var now = Date(timeIntervalSince1970: 1669681800)
+        var schedulingCards = f.repeat(card: card, now: now)
+        
+        let ratingIvlList: [(Rating, Int)] = [
+            (.again, 0),
+            (.good, 0),
+            (.good, 1),
+            (.good, 3),
+            (.good, 8),
+            (.good, 21)
+        ]
+        
+        for (rating, ivl) in ratingIvlList {
+            card = schedulingCards[rating]!.card
+            now = Calendar.current.date(byAdding: .day, value: ivl, to: now)!
+            schedulingCards = f.repeat(card: card, now: now)
+        }
+        
+        XCTAssertEqual(schedulingCards[.good]!.card.stability, 43.0554, accuracy: 0.0001)
+        XCTAssertEqual(schedulingCards[.good]!.card.difficulty, 7.7609, accuracy: 0.0001)
     }
 
     func log(schedulingInfo: [Rating: SchedulingInfo]) {


### PR DESCRIPTION
Hey, this PR updates the algorithm to FSRS 4.5.

## Changes

- Introduced `decay` and `factor` params
- Updated forgetting curve calculation
- Simplified some of the code for clarity and deduplication
- Fixed tests to pass again

## Sources

New values for the forgetting curve etc. have been taken from:
- https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-45
- https://github.com/open-spaced-repetition/go-fsrs/blob/main/params.go
- https://github.com/open-spaced-repetition/go-fsrs/blob/main/fsrs.go

Further, the tests have been updates to use the same values (for date and weights) as the Go tests:
- https://github.com/open-spaced-repetition/go-fsrs/blob/main/fsrs_test.go

This should make it easier to maintain both versions in the future and test them against each other.

## Misc

Resolves #10