### PR TITLE
FSRS v6 implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
-A Swift implementation of FSRS5.0
+A Swift implementation of FSRS-6.0 (FSRS-5.0 supported via 19-length `w`).
 
 [![codecov](https://codecov.io/gh/open-spaced-repetition/swift-fsrs/graph/badge.svg?token=K2C0Z5PFEH)](https://codecov.io/gh/open-spaced-repetition/swift-fsrs)
+
+```swift
+import FSRS
+
+// v5 (default — 19-length w):
+let v5 = FSRS(parameters: .init())
+
+// v6 — pass a 21-length w (e.g. the canonical default):
+let v6 = FSRS(parameters: .init(w: FSRSDefaults.defaultWv6))
+
+let card = FSRSDefaults().createEmptyCard()
+let next = try v6.next(card: card, now: Date(), grade: .good).card
+```

--- a/Sources/FSRS/Algorithm/FSRS.swift
+++ b/Sources/FSRS/Algorithm/FSRS.swift
@@ -10,15 +10,15 @@ public class FSRS: FSRSAlgorithm {
     
     override func processparameters(_ parameters: FSRSParameters) {
         let parameters = defaults.generatorParameters(props: parameters)
+        if parameters != self.parameters {
+            self.parameters = parameters
+        }
         if parameters.requestRetention.isFinite {
             do {
                 intervalModifier = try calculateIntervalModifier(requestRetention: parameters.requestRetention)
             } catch {
                 print(error.localizedDescription)
             }
-        }
-        if parameters != self.parameters {
-            self.parameters = parameters
         }
     }
     
@@ -89,9 +89,7 @@ public class FSRS: FSRSAlgorithm {
         now: Date,
         _ completion: ((_ log: IPreview) -> IPreview)? = nil
     ) -> IPreview {
-        let obj = params.enableShortTerm
-        ? BasicScheduler(card: card, reviewTime: now, algorithm: self)
-        : LongTermScheduler(card: card, reviewTime: now, algorithm: self)
+        let obj = scheduler(for: card, reviewTime: now)
         let log = obj.preview
         if let completion = completion {
             return completion(log)
@@ -163,14 +161,31 @@ public class FSRS: FSRSAlgorithm {
         if grade == .manual {
             throw FSRSError(.invalidRating, "Cannot review a manual rating")
         }
-        let obj = params.enableShortTerm
-        ? BasicScheduler(card: card, reviewTime: now, algorithm: self)
-        : LongTermScheduler(card: card, reviewTime: now, algorithm: self)
+        let obj = scheduler(for: card, reviewTime: now)
         let log = obj.review(grade)
         if let completion = completion {
             return completion(log)
         } else {
             return log
+        }
+    }
+
+    /// Picks the appropriate scheduler for the active algorithm version and
+    /// `enableShortTerm` setting:
+    /// - `enableShortTerm == false`: shared `LongTermScheduler` (works for both
+    ///   v5 and v6 because long-term mode collapses w17/w18 to 0).
+    /// - `v5 + enableShortTerm`: legacy `BasicScheduler` (hardcoded 1m/5m/10m).
+    /// - `v6 + enableShortTerm`: `BasicSchedulerV6` (configurable steps,
+    ///   delegates state transitions to `algorithm.nextState`).
+    private func scheduler(for card: Card, reviewTime: Date) -> AbstractScheduler {
+        if !params.enableShortTerm {
+            return LongTermScheduler(card: card, reviewTime: reviewTime, algorithm: self)
+        }
+        switch version {
+        case .v5:
+            return BasicScheduler(card: card, reviewTime: reviewTime, algorithm: self)
+        case .v6:
+            return BasicSchedulerV6(card: card, reviewTime: reviewTime, algorithm: self)
         }
     }
     
@@ -256,6 +271,7 @@ public class FSRS: FSRSAlgorithm {
         previousCard.difficulty = processedLog.difficulty ?? 0
         previousCard.elapsedDays = processedLog.lastElapsedDays
         previousCard.scheduledDays = processedLog.scheduledDays
+        previousCard.learningSteps = processedLog.learningSteps
         previousCard.reps = max(0, processdCard.reps - 1)
         previousCard.lapses = max(0, lastLapses)
         previousCard.state = state

--- a/Sources/FSRS/Algorithm/FSRS.swift
+++ b/Sources/FSRS/Algorithm/FSRS.swift
@@ -88,9 +88,9 @@ public class FSRS: FSRSAlgorithm {
         card: Card,
         now: Date,
         _ completion: ((_ log: IPreview) -> IPreview)? = nil
-    ) -> IPreview {
+    ) throws -> IPreview {
         let obj = scheduler(for: card, reviewTime: now)
-        let log = obj.preview
+        let log = try obj.preview
         if let completion = completion {
             return completion(log)
         } else {
@@ -162,7 +162,7 @@ public class FSRS: FSRSAlgorithm {
             throw FSRSError(.invalidRating, "Cannot review a manual rating")
         }
         let obj = scheduler(for: card, reviewTime: now)
-        let log = obj.review(grade)
+        let log = try obj.review(grade)
         if let completion = completion {
             return completion(log)
         } else {

--- a/Sources/FSRS/Algorithm/FSRSAlgorithm.swift
+++ b/Sources/FSRS/Algorithm/FSRSAlgorithm.swift
@@ -9,20 +9,45 @@ import Foundation
  * @see https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-45
  */
 public class FSRSAlgorithm {
+    /// Algorithm version inferred from the length of the active `w` vector.
+    /// Drives version-dispatched formulas (decay, factor, S_MIN, init difficulty
+    /// clamp location, short-term stability shape).
+    public var version: FSRSAlgorithmVersion {
+        FSRSAlgorithmVersion.detect(parameters.w)
+    }
+
+    /// Lower bound for stability. v5 = 0.01, v6 = 0.001 (matches upstream).
+    var sMin: Double {
+        switch version {
+        case .v5: return FSRSDefaults.S_MIN
+        case .v6: return FSRSDefaults.S_MIN_V6
+        }
+    }
+
     /**
-     * @default DECAY = -0.5
+     * @default DECAY = -0.5 for v5 ; -w[20] for v6
      */
-    let decay = -0.5
+    var decay: Double {
+        switch version {
+        case .v5: return -0.5
+        case .v6: return -parameters.w[20]
+        }
+    }
     /**
-     * FACTOR = Math.pow(0.9, 1 / DECAY) - 1= 19 / 81
+     * FACTOR = Math.pow(0.9, 1 / DECAY) - 1
      *
-     * $$\text{FACTOR} = \frac{19}{81}$$
-     * @default FACTOR = 19 / 81
+     * $$\text{FACTOR} = \frac{19}{81}$$ for v5 (decay = -0.5); derived from
+     * `w[20]` for v6.
      */
-    let factor: Double = 19 / 81
-    
+    var factor: Double {
+        switch version {
+        case .v5: return 19.0 / 81.0
+        case .v6: return (exp(log(0.9) / decay) - 1.0).toFixedNumber(8)
+        }
+    }
+
     let defaults = FSRSDefaults()
-    
+
     internal var parameters: FSRSParameters
 
     var params: FSRSParameters {
@@ -36,6 +61,12 @@ public class FSRSAlgorithm {
 
     func processparameters(_ parameters: FSRSParameters) {
         let parameters = defaults.generatorParameters(props: parameters)
+        // Assign self.parameters BEFORE computing intervalModifier — for v6
+        // that derivation reads w[20] via `decay`, and the value depends on
+        // the migrated/clamped parameters, not the raw input.
+        if parameters != self.parameters {
+            self.parameters = parameters
+        }
         if parameters.requestRetention.isFinite {
             do {
                 intervalModifier = try calculateIntervalModifier(
@@ -44,16 +75,12 @@ public class FSRSAlgorithm {
             } catch {
                 print(error.localizedDescription)
             }
-
-        }
-        if parameters != self.parameters {
-            self.parameters = parameters
         }
     }
 
     var intervalModifier: Double = 1
     var seed: String?
-    
+
     init(parameters: FSRSParameters) {
         self.parameters = parameters
         processparameters(parameters)
@@ -95,10 +122,19 @@ public class FSRSAlgorithm {
      * @param {Grade} g Grade (rating at Anki) [1.again,2.hard,3.good,4.easy]
      * @return {number} Difficulty $$D \in [1,10]$$
      */
+    /// Initial difficulty, clamped to `[1, 10]`. Used as the canonical entry
+    /// point — both v5 and v6 callers see clamped values here.
     func initDifficulty(_ grade: Rating) -> Double {
         constrainDifficulty(
             r: parameters.w[4] - exp((Double(grade.rawValue) - 1) * parameters.w[5]) + 1
         )
+    }
+
+    /// Raw, unclamped initial difficulty as defined by FSRS-6's
+    /// `init_difficulty`. Used by v6's `nextDifficulty` for mean reversion,
+    /// where the unclamped Easy-init value matters.
+    func initDifficultyRaw(_ grade: Rating) -> Double {
+        (parameters.w[4] - exp(Double(grade.rawValue - 1) * parameters.w[5]) + 1).toFixedNumber(8)
     }
 
     func constrainDifficulty(r: Double) -> Double {
@@ -152,7 +188,15 @@ public class FSRSAlgorithm {
     func nextDifficulty(d: Double, g: Rating) -> Double {
         let deltaD = -(parameters.w[6] * Double(g.rawValue - 3))
         let nextD = d + linearDamping(deltaD: deltaD, oldD: d)
-        return constrainDifficulty(r: meanReversion(initValue: initDifficulty(.easy), current: nextD))
+        // v5 mean-reverts toward the *clamped* easy-init value; v6 mean-reverts
+        // toward the *raw* easy-init value (this is part of v6's clamp-at-caller
+        // refactor and changes outputs even when w is otherwise comparable).
+        let initEasy: Double
+        switch version {
+        case .v5: initEasy = initDifficulty(.easy)
+        case .v6: initEasy = initDifficultyRaw(.easy)
+        }
+        return constrainDifficulty(r: meanReversion(initValue: initEasy, current: nextD))
     }
     
     /**
@@ -174,7 +218,7 @@ public class FSRSAlgorithm {
                 1 + exp(parameters.w[8]) * (11 - d) * pow(s, -(parameters.w[9])) *
                 (exp((1 - r) * parameters.w[10]) - 1) * hardPenalty * easyBound
             ),
-            0.01,
+            sMin,
             36500
         )
         .toFixedNumber(8)
@@ -196,7 +240,7 @@ public class FSRSAlgorithm {
         let p3 = exp((1 - r) * parameters.w[14])
         return FSRSHelper.clamp(
             parameters.w[11] * p1 * p2 * p3,
-            FSRSDefaults.S_MIN,
+            sMin,
             36500
         ).toFixedNumber(8)
     }
@@ -209,11 +253,25 @@ public class FSRSAlgorithm {
      */
     func nextShortTermStability(s: Double, g: Rating) -> Double {
         let part = Double(g.rawValue) - 3 + parameters.w[18]
-        return FSRSHelper.clamp(
-            s * exp(parameters.w[17] * part),
-            FSRSDefaults.S_MIN,
-            36500
-        ).toFixedNumber(8)
+        switch version {
+        case .v5:
+            return FSRSHelper.clamp(
+                s * exp(parameters.w[17] * part),
+                sMin,
+                36500
+            ).toFixedNumber(8)
+        case .v6:
+            // v6 introduces an extra `s^-w[19]` factor and a Hard/Easy floor:
+            // when sinc < 1 for grade ≥ Hard, snap it to 1 so non-Again grades
+            // never *shrink* stability under short-term scheduling.
+            let sinc = pow(s, -parameters.w[19]) * exp(parameters.w[17] * part)
+            let masked = g.rawValue >= Rating.hard.rawValue ? max(sinc, 1.0) : sinc
+            return FSRSHelper.clamp(
+                s * masked,
+                sMin,
+                36500
+            ).toFixedNumber(8)
+        }
     }
 
     /**
@@ -247,7 +305,7 @@ public class FSRSAlgorithm {
         if g == .manual {
             return FSRSState(stability: stability, difficulty: difficulty)
         }
-        if difficulty < 1 || stability < FSRSDefaults.S_MIN {
+        if difficulty < 1 || stability < sMin {
             throw FSRSError(.invalidParam)
         }
         let r = forgettingCurve(elapsedDays: t, stability: stability)
@@ -255,7 +313,7 @@ public class FSRSAlgorithm {
         let sAfterFail = nextForgetStability(d: difficulty, s: stability, r: r)
         let sAfterShortTerm = nextShortTermStability(s: stability, g: g)
         var newS = sAfterSuccess
-        
+
         if g == .again {
             var w17 = 0.0
             var w18 = 0.0
@@ -264,14 +322,14 @@ public class FSRSAlgorithm {
                 w18 = params.w[18]
             }
             let nextSMin = stability / exp(w17 * w18)
-            newS = FSRSHelper.clamp(nextSMin, FSRSDefaults.S_MIN, sAfterFail)
+            newS = FSRSHelper.clamp(nextSMin, sMin, sAfterFail)
         }
-        
+
         if t == 0 && params.enableShortTerm {
             newS = sAfterShortTerm
         }
-        
-        var newD = nextDifficulty(d: difficulty, g: g)
+
+        let newD = nextDifficulty(d: difficulty, g: g)
         return FSRSState(stability: newS, difficulty: newD)
     }
 }

--- a/Sources/FSRS/Algorithm/FSRSAlgorithm.swift
+++ b/Sources/FSRS/Algorithm/FSRSAlgorithm.swift
@@ -294,8 +294,8 @@ public class FSRSAlgorithm {
       * @returns The next state of memory with updated difficulty and stability.
       */
     func nextState(memoryState: FSRSState?, t: Double, g: Rating) throws -> FSRSState {
-        var difficulty = memoryState?.difficulty ?? 0.0
-        var stability = memoryState?.stability ?? 0.0
+        let difficulty = memoryState?.difficulty ?? 0.0
+        let stability = memoryState?.stability ?? 0.0
         if t < 0 {
             throw FSRSError.init(.invalidDeltaT)
         }

--- a/Sources/FSRS/Helper/FSRSSteps.swift
+++ b/Sources/FSRS/Helper/FSRSSteps.swift
@@ -1,0 +1,113 @@
+//
+//  FSRSSteps.swift
+//
+//  Step parsing and the BasicLearningStepsStrategy used by the v6 scheduler.
+//  Mirrors ts-fsrs's `strategies/learning_steps.ts` and `models.ts` step types.
+//
+
+import Foundation
+
+/// Per-grade outcome from a learning-steps strategy.
+public struct LearningStepOutcome: Equatable {
+    /// Schedule the card this many minutes from now (rounded). 0 means the
+    /// strategy has no opinion — the scheduler should fall through to
+    /// algorithm-driven intervals.
+    public let scheduledMinutes: Int
+    /// `Card.learningSteps` value to set on the resulting card.
+    public let nextStep: Int
+}
+
+/// Strategy signature: given parameters, the card's current state, and the
+/// current step index, return per-grade outcomes. Grades not present in the
+/// dictionary fall through to algorithm-driven scheduling (typical for
+/// `.easy`, and for `.hard`/`.good` when no step entry applies).
+public typealias LearningStepsStrategy = (
+    _ params: FSRSParameters,
+    _ state: CardState,
+    _ curStep: Int
+) -> [Rating: LearningStepOutcome]
+
+/// Convert a step unit string (`"1m"`, `"10m"`, `"1h"`, `"1d"`) to minutes.
+/// Throws if the string is malformed.
+public func convertStepUnitToMinutes(_ step: String) throws -> Int {
+    guard let last = step.last else {
+        throw FSRSError(.invalidParam, "Empty step unit")
+    }
+    let valuePart = String(step.dropLast())
+    guard let value = Int(valuePart), value >= 0 else {
+        throw FSRSError(.invalidParam, "Invalid step value: \(step)")
+    }
+    switch last {
+    case "m": return value
+    case "h": return value * 60
+    case "d": return value * 1440
+    default:
+        throw FSRSError(.invalidParam, "Invalid step unit: \(step), expected m/h/d")
+    }
+}
+
+/// Match JavaScript `Math.round` semantics: half values round away from zero
+/// (e.g. 5.5 → 6, -1.5 → -2). Swift's default `.rounded()` uses banker's
+/// rounding, which would diverge on exact halves.
+@inline(__always)
+private func jsRound(_ x: Double) -> Int {
+    Int(x.rounded(.toNearestOrAwayFromZero))
+}
+
+/// Reference learning-steps strategy mirroring ts-fsrs's
+/// `BasicLearningStepsStrategy`.
+///
+/// Behavior:
+/// - State `.review` (Again was pressed on a Review card) returns only the
+///   `.again` outcome with `scheduled_minutes = relearning_steps[curStep]`,
+///   pushing the card into Relearning.
+/// - Otherwise, `.again` resets to the first step, `.hard` repeats the
+///   current step (with a derived interval), and `.good` advances to the
+///   next step (if any). `.easy` is never set — it always graduates to
+///   Review via algorithm-driven scheduling.
+public func basicLearningStepsStrategy(
+    params: FSRSParameters,
+    state: CardState,
+    curStep: Int
+) -> [Rating: LearningStepOutcome] {
+    let steps: [String] = (state == .relearning || state == .review)
+        ? params.relearningSteps
+        : params.learningSteps
+    let stepsLength = steps.count
+
+    if stepsLength == 0 || curStep >= stepsLength { return [:] }
+
+    var result: [Rating: LearningStepOutcome] = [:]
+
+    if state == .review {
+        let info = steps[max(0, curStep)]
+        guard let mins = try? convertStepUnitToMinutes(info) else { return [:] }
+        result[.again] = LearningStepOutcome(scheduledMinutes: mins, nextStep: 0)
+        return result
+    }
+
+    let firstStep = steps[0]
+    guard let firstMins = try? convertStepUnitToMinutes(firstStep) else { return [:] }
+
+    // Hard interval:
+    //   1 step  → round(first * 1.5)
+    //   N steps → round((first + second) / 2)
+    let hardInterval: Int
+    if stepsLength == 1 {
+        hardInterval = jsRound(Double(firstMins) * 1.5)
+    } else {
+        guard let secondMins = try? convertStepUnitToMinutes(steps[1]) else { return [:] }
+        hardInterval = jsRound(Double(firstMins + secondMins) / 2.0)
+    }
+
+    result[.again] = LearningStepOutcome(scheduledMinutes: firstMins, nextStep: 0)
+    result[.hard] = LearningStepOutcome(scheduledMinutes: hardInterval, nextStep: curStep)
+
+    let nextIdx = curStep + 1
+    if nextIdx < stepsLength,
+       let nextMins = try? convertStepUnitToMinutes(steps[nextIdx]) {
+        result[.good] = LearningStepOutcome(scheduledMinutes: nextMins, nextStep: nextIdx)
+    }
+
+    return result
+}

--- a/Sources/FSRS/Helper/FSRSSteps.swift
+++ b/Sources/FSRS/Helper/FSRSSteps.swift
@@ -20,12 +20,13 @@ public struct LearningStepOutcome: Equatable {
 /// Strategy signature: given parameters, the card's current state, and the
 /// current step index, return per-grade outcomes. Grades not present in the
 /// dictionary fall through to algorithm-driven scheduling (typical for
-/// `.easy`, and for `.hard`/`.good` when no step entry applies).
+/// `.easy`, and for `.hard`/`.good` when no step entry applies). Throws
+/// `FSRSError(.invalidParam)` when a step string is malformed (e.g. `"5x"`).
 public typealias LearningStepsStrategy = (
     _ params: FSRSParameters,
     _ state: CardState,
     _ curStep: Int
-) -> [Rating: LearningStepOutcome]
+) throws -> [Rating: LearningStepOutcome]
 
 /// Convert a step unit string (`"1m"`, `"10m"`, `"1h"`, `"1d"`) to minutes.
 /// Throws if the string is malformed.
@@ -65,11 +66,15 @@ private func jsRound(_ x: Double) -> Int {
 ///   current step (with a derived interval), and `.good` advances to the
 ///   next step (if any). `.easy` is never set — it always graduates to
 ///   Review via algorithm-driven scheduling.
+///
+/// Throws `FSRSError(.invalidParam)` if any consulted step string is
+/// malformed. This intentionally fails the review attempt rather than
+/// silently graduating the card on a typo'd config.
 public func basicLearningStepsStrategy(
     params: FSRSParameters,
     state: CardState,
     curStep: Int
-) -> [Rating: LearningStepOutcome] {
+) throws -> [Rating: LearningStepOutcome] {
     let steps: [String] = (state == .relearning || state == .review)
         ? params.relearningSteps
         : params.learningSteps
@@ -81,13 +86,12 @@ public func basicLearningStepsStrategy(
 
     if state == .review {
         let info = steps[max(0, curStep)]
-        guard let mins = try? convertStepUnitToMinutes(info) else { return [:] }
+        let mins = try convertStepUnitToMinutes(info)
         result[.again] = LearningStepOutcome(scheduledMinutes: mins, nextStep: 0)
         return result
     }
 
-    let firstStep = steps[0]
-    guard let firstMins = try? convertStepUnitToMinutes(firstStep) else { return [:] }
+    let firstMins = try convertStepUnitToMinutes(steps[0])
 
     // Hard interval:
     //   1 step  → round(first * 1.5)
@@ -96,7 +100,7 @@ public func basicLearningStepsStrategy(
     if stepsLength == 1 {
         hardInterval = jsRound(Double(firstMins) * 1.5)
     } else {
-        guard let secondMins = try? convertStepUnitToMinutes(steps[1]) else { return [:] }
+        let secondMins = try convertStepUnitToMinutes(steps[1])
         hardInterval = jsRound(Double(firstMins + secondMins) / 2.0)
     }
 
@@ -104,8 +108,8 @@ public func basicLearningStepsStrategy(
     result[.hard] = LearningStepOutcome(scheduledMinutes: hardInterval, nextStep: curStep)
 
     let nextIdx = curStep + 1
-    if nextIdx < stepsLength,
-       let nextMins = try? convertStepUnitToMinutes(steps[nextIdx]) {
+    if nextIdx < stepsLength {
+        let nextMins = try convertStepUnitToMinutes(steps[nextIdx])
         result[.good] = LearningStepOutcome(scheduledMinutes: nextMins, nextStep: nextIdx)
     }
 

--- a/Sources/FSRS/Models/FSRSDefaults.swift
+++ b/Sources/FSRS/Models/FSRSDefaults.swift
@@ -6,9 +6,42 @@
 
 import Foundation
 
+/// Algorithm version, derived from the length of the `w` parameter vector.
+///
+/// - `.v5` — 19-element `w` (legacy default, frozen for parity with existing tests).
+/// - `.v6` — 21-element `w` (FSRS-6.0). `w[19]` is the short-term last-stability
+///   exponent; `w[20]` is the learnable decay (defaults to 0.1542).
+public enum FSRSAlgorithmVersion: Equatable {
+    case v5
+    case v6
+
+    /// Infer version from a `w` vector. 19-length is v5; 21-length is v6.
+    /// 17-length (legacy v4) is treated as v5 because the existing migration
+    /// path pads to 19, not 21.
+    public static func detect(_ w: [Double]) -> FSRSAlgorithmVersion {
+        w.count == 21 ? .v6 : .v5
+    }
+}
+
 public class FSRSDefaults {
+    /// Lower bound for stability under FSRS-5 semantics.
     static let S_MIN = 0.01
+    /// Lower bound for stability under FSRS-6 semantics (matches upstream ts-fsrs).
+    static let S_MIN_V6 = 0.001
     static let INIT_S_MAX = 100.0
+
+    /// Decay value that, when used as `w[20]`, makes v6's learnable decay match v5's
+    /// constant `decay = -0.5` (i.e. `factor = 19/81`). Used when migrating 17- or
+    /// 19-length parameters into v6 land.
+    static let FSRS5_DEFAULT_DECAY = 0.5
+    /// Default decay for fresh v6 models (canonical value from ts-fsrs).
+    static let FSRS6_DEFAULT_DECAY = 0.1542
+
+    /// Default ceiling for `w[17]` and `w[18]` when relearning_steps is empty
+    /// or has length ≤ 1. ts-fsrs derives a tighter ceiling from the relearning
+    /// steps count when > 1 (see `clampParametersV6`).
+    static let W17_W18_CEILING = 2.0
+
     static let CLAMP_PARAMETERS = [
         [S_MIN, INIT_S_MAX] /** initial stability (Again) */,
         [S_MIN, INIT_S_MAX] /** initial stability (Hard) */,
@@ -31,6 +64,41 @@ public class FSRSDefaults {
         [0.0, 2.0] /** short-term stability (exponent) */,
     ]
 
+    /// V6 clamp ranges. Mirrors ts-fsrs's CLAMP_PARAMETERS function: rows 17/18
+    /// share a configurable ceiling; row 19 (short-term last-stability exponent)
+    /// has a lower bound that depends on `enable_short_term`; row 20 is decay.
+    static func clampParametersV6(
+        w17W18Ceiling: Double = W17_W18_CEILING,
+        enableShortTerm: Bool = true
+    ) -> [[Double]] {
+        let base = CLAMP_PARAMETERS
+            .prefix(17)
+            .map { $0 } + [
+                [0.0, w17W18Ceiling] /** short-term stability (exponent) */,
+                [0.0, w17W18Ceiling] /** short-term stability (exponent) */,
+                [enableShortTerm ? 0.01 : 0.0, 0.8] /** short-term last-stability (exponent) */,
+                [0.1, 0.8] /** decay */,
+            ]
+        return base
+    }
+
+    /// Compute the dynamic `w17_w18_ceiling` from the relearning step count.
+    /// Mirrors ts-fsrs's clipParameters derivation exactly.
+    static func computeW17W18Ceiling(parameters: [Double], numRelearningSteps: Int) -> Double {
+        guard max(0, numRelearningSteps) > 1 else { return W17_W18_CEILING }
+        // PLS = w11 * D ^ -w12 * [(S + 1) ^ w13 - 1] * e ^ (w14 * (1 - R))
+        // Given D = 1, R = 0.7, S = 1, this collapses to:
+        //   PLS = w11 * (2 ^ w13 - 1) * e ^ (w14 * 0.3)
+        // We require PLS * e ^ (n * w17 * w18) ≤ S = 1, so:
+        //   n * w17 * w18 ≤ -[ln(w11) + ln(2 ^ w13 - 1) + w14 * 0.3]
+        let value = -(
+            log(parameters[11]) +
+            log(pow(2.0, parameters[13]) - 1.0) +
+            parameters[14] * 0.3
+        ) / Double(numRelearningSteps)
+        return FSRSHelper.clamp(value.toFixedNumber(8), 0.01, 2.0)
+    }
+
     var defaultRequestRetention = 0.9
     var defaultMaximumInterval = 36500.0
     let defaultW = [
@@ -39,17 +107,36 @@ public class FSRSDefaults {
         1.01925, 1.9395, 0.11, 0.29605, 2.2698,
         0.2315, 2.9898, 0.51655, 0.6621
     ]
+    /// Canonical FSRS-6.0 default `w` (21 elements). Pass this to `FSRSParameters`
+    /// to opt in to v6 semantics.
+    public static let defaultWv6: [Double] = [
+        0.212, 1.2931, 2.3065, 8.2956, 6.4133,
+        0.8334, 3.0194, 0.001, 1.8722, 0.1666,
+        0.796, 1.4835, 0.0614, 0.2629, 1.6483,
+        0.6014, 1.8729, 0.5425, 0.0912, 0.0658,
+        FSRS6_DEFAULT_DECAY,
+    ]
     var defaultEnableFuzz = false
     var defaultEnableShortTerm = true
+
+    /// Default learning steps used by v6 schedulers (no effect under v5).
+    public static let defaultLearningSteps: [String] = ["1m", "10m"]
+    /// Default relearning steps used by v6 schedulers (no effect under v5).
+    public static let defaultRelearningSteps: [String] = ["10m"]
 
     var FSRSVersion: String = "v5.1.0 using FSRS-5.0"
 
     func generatorParameters(props: FSRSParameters? = nil) -> FSRSParameters {
         var w = defaultW
+        let inputCount = props?.w.count ?? -1
+
         if let p = props {
-            if p.w.count == 19 {
+            switch p.w.count {
+            case 21:
                 w = p.w
-            } else if p.w.count == 17 {
+            case 19:
+                w = p.w
+            case 17:
                 w = p.w
                 w.append(0.0)
                 w.append(0.0)
@@ -57,21 +144,51 @@ public class FSRSDefaults {
                 w[5] = (log(w[5] * 3.0 + 1.0) / 3.0).toFixedNumber(8)
                 w[6] = (w[6] + 0.5).toFixedNumber(8)
                 print("[FSRS V5]auto fill w to 19 length")
+            default:
+                break
             }
         }
+
+        let enableShortTerm = props?.enableShortTerm ?? defaultEnableShortTerm
+        let learningSteps = props?.learningSteps ?? Self.defaultLearningSteps
+        let relearningSteps = props?.relearningSteps ?? Self.defaultRelearningSteps
+
+        // Pick the right clamp table based on the (possibly migrated) w length.
+        let clampTable: [[Double]]
+        if w.count == 21 {
+            let ceiling = Self.computeW17W18Ceiling(
+                parameters: w,
+                numRelearningSteps: relearningSteps.count
+            )
+            clampTable = Self.clampParametersV6(
+                w17W18Ceiling: ceiling,
+                enableShortTerm: enableShortTerm
+            )
+        } else {
+            clampTable = Self.CLAMP_PARAMETERS
+        }
+
         w = w.enumerated().map({
-            FSRSHelper.clamp($0.element, Self.CLAMP_PARAMETERS[$0.offset][0], Self.CLAMP_PARAMETERS[$0.offset][1])
+            FSRSHelper.clamp($0.element, clampTable[$0.offset][0], clampTable[$0.offset][1])
         })
+
+        // 17→19 (legacy v4→v5) was already handled above. Note: we deliberately do
+        // NOT auto-migrate 19→21. Callers who want v6 must pass a 21-length w
+        // (e.g. FSRSDefaults.defaultWv6) — silent migration would change behavior.
+        _ = inputCount
+
         return FSRSParameters(
             requestRetention: props?.requestRetention ?? defaultRequestRetention,
             maximumInterval: props?.maximumInterval ?? defaultMaximumInterval,
             w: w,
             enableFuzz: props?.enableFuzz ?? defaultEnableFuzz,
-            enableShortTerm: props?.enableShortTerm ?? defaultEnableShortTerm
+            enableShortTerm: enableShortTerm,
+            learningSteps: learningSteps,
+            relearningSteps: relearningSteps
         )
     }
 
-    
+
     /**
      * Create an empty card
      * @param now Current time

--- a/Sources/FSRS/Models/FSRSDefaults.swift
+++ b/Sources/FSRS/Models/FSRSDefaults.swift
@@ -137,7 +137,6 @@ public class FSRSDefaults {
 
     func generatorParameters(props: FSRSParameters? = nil) -> FSRSParameters {
         var w = defaultW
-        let inputCount = props?.w.count ?? -1
 
         if let p = props {
             switch p.w.count {
@@ -184,7 +183,6 @@ public class FSRSDefaults {
         // 17→19 (legacy v4→v5) was already handled above. Note: we deliberately do
         // NOT auto-migrate 19→21. Callers who want v6 must pass a 21-length w
         // (e.g. FSRSDefaults.defaultWv6) — silent migration would change behavior.
-        _ = inputCount
 
         return FSRSParameters(
             requestRetention: props?.requestRetention ?? defaultRequestRetention,

--- a/Sources/FSRS/Models/FSRSDefaults.swift
+++ b/Sources/FSRS/Models/FSRSDefaults.swift
@@ -30,10 +30,6 @@ public class FSRSDefaults {
     static let S_MIN_V6 = 0.001
     static let INIT_S_MAX = 100.0
 
-    /// Decay value that, when used as `w[20]`, makes v6's learnable decay match v5's
-    /// constant `decay = -0.5` (i.e. `factor = 19/81`). Used when migrating 17- or
-    /// 19-length parameters into v6 land.
-    static let FSRS5_DEFAULT_DECAY = 0.5
     /// Default decay for fresh v6 models (canonical value from ts-fsrs).
     static let FSRS6_DEFAULT_DECAY = 0.1542
 

--- a/Sources/FSRS/Models/FSRSDefaults.swift
+++ b/Sources/FSRS/Models/FSRSDefaults.swift
@@ -84,17 +84,26 @@ public class FSRSDefaults {
 
     /// Compute the dynamic `w17_w18_ceiling` from the relearning step count.
     /// Mirrors ts-fsrs's clipParameters derivation exactly.
+    ///
+    /// `parameters` is the *raw* w vector — generatorParameters calls this
+    /// before clamping. Pre-clamp the values feeding into `log(...)` so an
+    /// out-of-range `w[11]` / `w[13]` / `w[14]` can't NaN-poison the ceiling
+    /// (and through it the rest of the clamp table). Math is unchanged for
+    /// any in-range input.
     static func computeW17W18Ceiling(parameters: [Double], numRelearningSteps: Int) -> Double {
         guard max(0, numRelearningSteps) > 1 else { return W17_W18_CEILING }
+        let w11 = FSRSHelper.clamp(parameters[11], 0.001, 5.0)
+        let w13 = FSRSHelper.clamp(parameters[13], 0.001, 0.9)
+        let w14 = FSRSHelper.clamp(parameters[14], 0.0, 4.0)
         // PLS = w11 * D ^ -w12 * [(S + 1) ^ w13 - 1] * e ^ (w14 * (1 - R))
         // Given D = 1, R = 0.7, S = 1, this collapses to:
         //   PLS = w11 * (2 ^ w13 - 1) * e ^ (w14 * 0.3)
         // We require PLS * e ^ (n * w17 * w18) ≤ S = 1, so:
         //   n * w17 * w18 ≤ -[ln(w11) + ln(2 ^ w13 - 1) + w14 * 0.3]
         let value = -(
-            log(parameters[11]) +
-            log(pow(2.0, parameters[13]) - 1.0) +
-            parameters[14] * 0.3
+            log(w11) +
+            log(pow(2.0, w13) - 1.0) +
+            w14 * 0.3
         ) / Double(numRelearningSteps)
         return FSRSHelper.clamp(value.toFixedNumber(8), 0.01, 2.0)
     }

--- a/Sources/FSRS/Models/FSRSModels.swift
+++ b/Sources/FSRS/Models/FSRSModels.swift
@@ -45,6 +45,9 @@ public struct ReviewLog: Equatable, Codable, Hashable {
     public var elapsedDays: Double     // Number of days elapsed since the last review
     public var lastElapsedDays: Double // Number of days between the last two reviews
     public var scheduledDays: Double   // Number of days until the next review
+    /// Tracks the current (re)learning step index. Always 0 in v5 (the v5
+    /// scheduler doesn't expose configurable steps); meaningful only under v6.
+    public var learningSteps: Int      // 0 = not in a step
     public var review: Date            // Date of the review
 
     public init(
@@ -56,6 +59,7 @@ public struct ReviewLog: Equatable, Codable, Hashable {
         elapsedDays: Double = 0,
         lastElapsedDays: Double = 0,
         scheduledDays: Double = 0,
+        learningSteps: Int = 0,
         review: Date
     ) {
         self.rating = rating
@@ -66,7 +70,27 @@ public struct ReviewLog: Equatable, Codable, Hashable {
         self.elapsedDays = elapsedDays
         self.lastElapsedDays = lastElapsedDays
         self.scheduledDays = scheduledDays
+        self.learningSteps = learningSteps
         self.review = review
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case rating, state, due, stability, difficulty
+        case elapsedDays, lastElapsedDays, scheduledDays, learningSteps, review
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.rating = try c.decode(Rating.self, forKey: .rating)
+        self.state = try c.decodeIfPresent(CardState.self, forKey: .state)
+        self.due = try c.decodeIfPresent(Date.self, forKey: .due)
+        self.stability = try c.decodeIfPresent(Double.self, forKey: .stability)
+        self.difficulty = try c.decodeIfPresent(Double.self, forKey: .difficulty)
+        self.elapsedDays = try c.decodeIfPresent(Double.self, forKey: .elapsedDays) ?? 0
+        self.lastElapsedDays = try c.decodeIfPresent(Double.self, forKey: .lastElapsedDays) ?? 0
+        self.scheduledDays = try c.decodeIfPresent(Double.self, forKey: .scheduledDays) ?? 0
+        self.learningSteps = try c.decodeIfPresent(Int.self, forKey: .learningSteps) ?? 0
+        self.review = try c.decode(Date.self, forKey: .review)
     }
 
     public var newLog: ReviewLog {
@@ -79,6 +103,7 @@ public struct ReviewLog: Equatable, Codable, Hashable {
             elapsedDays: elapsedDays,
             lastElapsedDays: lastElapsedDays,
             scheduledDays: scheduledDays,
+            learningSteps: learningSteps,
             review: review
         )
     }
@@ -90,6 +115,9 @@ public struct Card: Equatable, Codable, Hashable {
     public var difficulty: Double    // Reflects the inherent difficulty of the card content
     public var elapsedDays: Double   // Days since the card was last reviewed
     public var scheduledDays: Double // The interval at which the card is next scheduled
+    /// Index of the current (re)learning step. 0 means "not currently in a
+    /// step". Always 0 under v5; meaningful under v6's `BasicSchedulerV6`.
+    public var learningSteps: Int
     public var reps: Int             // Total number of times the card has been reviewed
     public var lapses: Int           // Times the card was forgotten or remembered incorrectly
     public var state: CardState      // The current state of the card (New, Learning, Review, Relearning)
@@ -101,6 +129,7 @@ public struct Card: Equatable, Codable, Hashable {
         difficulty: Double = 0,
         elapsedDays: Double = 0,
         scheduledDays: Double = 0,
+        learningSteps: Int = 0,
         reps: Int = 0,
         lapses: Int = 0,
         state: CardState = .new,
@@ -111,10 +140,30 @@ public struct Card: Equatable, Codable, Hashable {
         self.difficulty = difficulty
         self.elapsedDays = elapsedDays
         self.scheduledDays = scheduledDays
+        self.learningSteps = learningSteps
         self.reps = reps
         self.lapses = lapses
         self.state = state
         self.lastReview = lastReview
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case due, stability, difficulty, elapsedDays, scheduledDays
+        case learningSteps, reps, lapses, state, lastReview
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.due = try c.decode(Date.self, forKey: .due)
+        self.stability = try c.decodeIfPresent(Double.self, forKey: .stability) ?? 0
+        self.difficulty = try c.decodeIfPresent(Double.self, forKey: .difficulty) ?? 0
+        self.elapsedDays = try c.decodeIfPresent(Double.self, forKey: .elapsedDays) ?? 0
+        self.scheduledDays = try c.decodeIfPresent(Double.self, forKey: .scheduledDays) ?? 0
+        self.learningSteps = try c.decodeIfPresent(Int.self, forKey: .learningSteps) ?? 0
+        self.reps = try c.decodeIfPresent(Int.self, forKey: .reps) ?? 0
+        self.lapses = try c.decodeIfPresent(Int.self, forKey: .lapses) ?? 0
+        self.state = try c.decodeIfPresent(CardState.self, forKey: .state) ?? .new
+        self.lastReview = try c.decodeIfPresent(Date.self, forKey: .lastReview)
     }
 
     public var newCard: Card {
@@ -124,6 +173,7 @@ public struct Card: Equatable, Codable, Hashable {
             difficulty: difficulty,
             elapsedDays: elapsedDays,
             scheduledDays: scheduledDays,
+            learningSteps: learningSteps,
             reps: reps,
             lapses: lapses,
             state: state,
@@ -161,13 +211,24 @@ public struct FSRSParameters: Codable, Equatable {
     public var w: [Double]
     public var enableFuzz: Bool
     public var enableShortTerm: Bool
-    
+    /// Configurable learning steps applied by the v6 BasicScheduler when
+    /// `enableShortTerm` is true. Each entry is a string like `"1m"`, `"10m"`,
+    /// `"1h"`, or `"1d"`. Has no effect under v5 (the v5 scheduler uses
+    /// hardcoded steps for backward compatibility).
+    public var learningSteps: [String]
+    /// Configurable relearning steps applied by the v6 BasicScheduler when
+    /// transitioning a Review card via `again` back into Relearning. Has no
+    /// effect under v5.
+    public var relearningSteps: [String]
+
     public init(
         requestRetention: Double? = nil,
         maximumInterval: Double? = nil,
         w: [Double]? = nil,
         enableFuzz: Bool? = nil,
-        enableShortTerm: Bool? = nil
+        enableShortTerm: Bool? = nil,
+        learningSteps: [String]? = nil,
+        relearningSteps: [String]? = nil
     ) {
         let defaults = FSRSDefaults()
         self.requestRetention = requestRetention ?? defaults.defaultRequestRetention
@@ -175,6 +236,25 @@ public struct FSRSParameters: Codable, Equatable {
         self.w = w ?? defaults.defaultW
         self.enableFuzz = enableFuzz ?? defaults.defaultEnableFuzz
         self.enableShortTerm = enableShortTerm ?? defaults.defaultEnableShortTerm
+        self.learningSteps = learningSteps ?? FSRSDefaults.defaultLearningSteps
+        self.relearningSteps = relearningSteps ?? FSRSDefaults.defaultRelearningSteps
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case requestRetention, maximumInterval, w, enableFuzz, enableShortTerm
+        case learningSteps, relearningSteps
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = FSRSDefaults()
+        self.requestRetention = try c.decodeIfPresent(Double.self, forKey: .requestRetention) ?? defaults.defaultRequestRetention
+        self.maximumInterval = try c.decodeIfPresent(Double.self, forKey: .maximumInterval) ?? defaults.defaultMaximumInterval
+        self.w = try c.decodeIfPresent([Double].self, forKey: .w) ?? defaults.defaultW
+        self.enableFuzz = try c.decodeIfPresent(Bool.self, forKey: .enableFuzz) ?? defaults.defaultEnableFuzz
+        self.enableShortTerm = try c.decodeIfPresent(Bool.self, forKey: .enableShortTerm) ?? defaults.defaultEnableShortTerm
+        self.learningSteps = try c.decodeIfPresent([String].self, forKey: .learningSteps) ?? FSRSDefaults.defaultLearningSteps
+        self.relearningSteps = try c.decodeIfPresent([String].self, forKey: .relearningSteps) ?? FSRSDefaults.defaultRelearningSteps
     }
 }
 

--- a/Sources/FSRS/Models/FSRSModels.swift
+++ b/Sources/FSRS/Models/FSRSModels.swift
@@ -45,9 +45,11 @@ public struct ReviewLog: Equatable, Codable, Hashable {
     public var elapsedDays: Double     // Number of days elapsed since the last review
     public var lastElapsedDays: Double // Number of days between the last two reviews
     public var scheduledDays: Double   // Number of days until the next review
-    /// Tracks the current (re)learning step index. Always 0 in v5 (the v5
-    /// scheduler doesn't expose configurable steps); meaningful only under v6.
-    public var learningSteps: Int      // 0 = not in a step
+    /// 0-based index into `params.learningSteps` / `relearningSteps`. Only
+    /// meaningful when the card's `state` is `.learning` or `.relearning` —
+    /// in `.new`/`.review` the value is just 0 because no step applies.
+    /// Always 0 under v5 (v5's scheduler doesn't expose configurable steps).
+    public var learningSteps: Int
     public var review: Date            // Date of the review
 
     public init(
@@ -115,8 +117,10 @@ public struct Card: Equatable, Codable, Hashable {
     public var difficulty: Double    // Reflects the inherent difficulty of the card content
     public var elapsedDays: Double   // Days since the card was last reviewed
     public var scheduledDays: Double // The interval at which the card is next scheduled
-    /// Index of the current (re)learning step. 0 means "not currently in a
-    /// step". Always 0 under v5; meaningful under v6's `BasicSchedulerV6`.
+    /// 0-based index into `params.learningSteps` / `relearningSteps`. Only
+    /// meaningful when `state` is `.learning` or `.relearning` — in
+    /// `.new`/`.review` the value is just 0 because no step applies. Always
+    /// 0 under v5 (v5's scheduler doesn't expose configurable steps).
     public var learningSteps: Int
     public var reps: Int             // Total number of times the card has been reviewed
     public var lapses: Int           // Times the card was forgotten or remembered incorrectly

--- a/Sources/FSRS/Models/FSRSTypes.swift
+++ b/Sources/FSRS/Models/FSRSTypes.swift
@@ -24,8 +24,8 @@ public struct IPreview {
 }
 
 public protocol IScheduler {
-    var preview: IPreview { get }
-    func review(_ g: Rating) -> RecordLogItem
+    var preview: IPreview { get throws }
+    func review(_ g: Rating) throws -> RecordLogItem
 }
 
 /**

--- a/Sources/FSRS/Scheduler/AbstractScheduler.swift
+++ b/Sources/FSRS/Scheduler/AbstractScheduler.swift
@@ -79,6 +79,7 @@ class AbstractScheduler: IScheduler {
               elapsedDays: current.elapsedDays,
               lastElapsedDays: last.elapsedDays,
               scheduledDays: current.scheduledDays,
+              learningSteps: current.learningSteps,
               review: reviewTime
         )
     }

--- a/Sources/FSRS/Scheduler/AbstractScheduler.swift
+++ b/Sources/FSRS/Scheduler/AbstractScheduler.swift
@@ -8,12 +8,14 @@ import Foundation
 
 class AbstractScheduler: IScheduler {
     var preview: IPreview {
-        .init(recordLog: [
-            .again: review(.again),
-            .hard: review(.hard),
-            .good: review(.good),
-            .easy: review(.easy)
-        ])
+        get throws {
+            .init(recordLog: [
+                .again: try review(.again),
+                .hard: try review(.hard),
+                .good: try review(.good),
+                .easy: try review(.easy)
+            ])
+        }
     }
     var last: Card
     var current: Card
@@ -46,26 +48,26 @@ class AbstractScheduler: IScheduler {
         set { algorithm.seed = newValue }
     }
 
-    func review(_ g: Rating) -> RecordLogItem {
+    func review(_ g: Rating) throws -> RecordLogItem {
         switch last.state {
         case .new:
-            return newState(grade: g)
+            return try newState(grade: g)
         case .learning, .relearning:
-            return learningState(grade: g)
+            return try learningState(grade: g)
         case .review:
-            return reviewState(grade: g)
+            return try reviewState(grade: g)
         }
     }
 
-    func newState(grade: Rating) -> RecordLogItem {
+    func newState(grade: Rating) throws -> RecordLogItem {
         print("subclass must override")
         return .init(card: Card(), log: ReviewLog(rating: .manual, state: .new, due: Date(), review: Date()))
     }
-    func learningState(grade: Rating) -> RecordLogItem {
+    func learningState(grade: Rating) throws -> RecordLogItem {
         print("subclass must override")
         return .init(card: Card(), log: ReviewLog(rating: .manual, state: .new, due: Date(), review: Date()))
     }
-    func reviewState(grade: Rating) -> RecordLogItem {
+    func reviewState(grade: Rating) throws -> RecordLogItem {
         print("subclass must override")
         return .init(card: Card(), log: ReviewLog(rating: .manual, state: .new, due: Date(), review: Date()))
     }

--- a/Sources/FSRS/Scheduler/BasicScheduler.swift
+++ b/Sources/FSRS/Scheduler/BasicScheduler.swift
@@ -143,7 +143,7 @@ class BasicScheduler: AbstractScheduler {
         nextAgain.difficulty = algorithm.nextDifficulty(d: difficulty, g: .again)
         let nextSMin = stability / exp(algorithm.parameters.w[17] * algorithm.parameters.w[18])
         let sAfterAll = algorithm.nextForgetStability(d: difficulty, s: stability, r: retrievability)
-        nextAgain.stability = FSRSHelper.clamp(nextSMin.toFixedNumber(8), FSRSDefaults.S_MIN, sAfterAll)
+        nextAgain.stability = FSRSHelper.clamp(nextSMin.toFixedNumber(8), algorithm.sMin, sAfterAll)
         
         nextHard.difficulty = algorithm.nextDifficulty(d: difficulty, g: .hard)
         nextHard.stability = algorithm.nextRecallStability(

--- a/Sources/FSRS/Scheduler/BasicScheduler.swift
+++ b/Sources/FSRS/Scheduler/BasicScheduler.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 class BasicScheduler: AbstractScheduler {
-    override func newState(grade: Rating) -> RecordLogItem {
+    override func newState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         var next = current.newCard
         next.difficulty = algorithm.initDifficulty(grade)
@@ -38,7 +38,7 @@ class BasicScheduler: AbstractScheduler {
         return .init(card: next, log: buildLog(rating: grade))
     }
 
-    override func learningState(grade: Rating) -> RecordLogItem {
+    override func learningState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         var next = current.newCard
         let interval = current.elapsedDays
@@ -82,7 +82,7 @@ class BasicScheduler: AbstractScheduler {
         return .init(card: next, log: buildLog(rating: grade))
     }
 
-    override func reviewState(grade: Rating) -> RecordLogItem {
+    override func reviewState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         let interval = current.elapsedDays
         let retrievability = algorithm.forgettingCurve(

--- a/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
+++ b/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
@@ -1,0 +1,159 @@
+//
+//  BasicSchedulerV6.swift
+//
+//  v6 BasicScheduler. Mirrors ts-fsrs's basic_scheduler.ts: delegates state
+//  transitions to algorithm.nextState and applies configurable
+//  learning/relearning steps via basicLearningStepsStrategy.
+//
+
+import Foundation
+
+class BasicSchedulerV6: AbstractScheduler {
+
+    private func getStepInfo(
+        grade: Rating,
+        fromState state: CardState,
+        curStep: Int
+    ) -> (scheduledMinutes: Int, nextStep: Int) {
+        let strategy = basicLearningStepsStrategy(
+            params: algorithm.parameters,
+            state: state,
+            curStep: curStep
+        )
+        let outcome = strategy[grade]
+        return (
+            scheduledMinutes: max(0, outcome?.scheduledMinutes ?? 0),
+            nextStep: max(0, outcome?.nextStep ?? 0)
+        )
+    }
+
+    private func applyLearningSteps(
+        nextCard: inout Card,
+        grade: Rating,
+        toState: CardState
+    ) {
+        let info = getStepInfo(
+            grade: grade,
+            fromState: current.state,
+            curStep: current.learningSteps
+        )
+        let mins = info.scheduledMinutes
+        let nextSteps = info.nextStep
+
+        if mins > 0 && mins < 1440 /** 1 day */ {
+            nextCard.learningSteps = nextSteps
+            nextCard.scheduledDays = 0
+            nextCard.state = toState
+            nextCard.due = Date.dateScheduler(now: reviewTime, t: Double(mins), unit: .minutes)
+        } else {
+            nextCard.state = .review
+            if mins >= 1440 {
+                nextCard.learningSteps = nextSteps
+                nextCard.due = Date.dateScheduler(now: reviewTime, t: Double(mins), unit: .minutes)
+                nextCard.scheduledDays = Double(mins / 1440)
+            } else {
+                nextCard.learningSteps = 0
+                let interval = algorithm.nextInterval(
+                    s: nextCard.stability,
+                    elapsedDays: current.elapsedDays
+                )
+                nextCard.scheduledDays = Double(interval)
+                nextCard.due = Date.dateScheduler(now: reviewTime, t: Double(interval), unit: .days)
+            }
+        }
+    }
+
+    /// Compute the next memory state via `algorithm.nextState`. v6's
+    /// `nextState` handles the new-card init, manual-rating short-circuit,
+    /// short-term path, again-clamp, and recall path internally — keeping
+    /// the scheduler thin.
+    private func nextDs(t: Double, grade: Rating) -> Card {
+        var card = current.newCard
+        do {
+            let memoryState = FSRSState(stability: current.stability, difficulty: current.difficulty)
+            let nextState = try algorithm.nextState(memoryState: memoryState, t: t, g: grade)
+            card.difficulty = nextState.difficulty
+            card.stability = nextState.stability
+        } catch {
+            // Defensive: shouldn't trigger for cards routed through this scheduler.
+            print(error.localizedDescription)
+        }
+        return card
+    }
+
+    override func newState(grade: Rating) -> RecordLogItem {
+        if let item = next[grade] { return item }
+        var card = nextDs(t: current.elapsedDays, grade: grade)
+        applyLearningSteps(nextCard: &card, grade: grade, toState: .learning)
+        let item = RecordLogItem(card: card, log: buildLog(rating: grade))
+        next[grade] = item
+        return item
+    }
+
+    override func learningState(grade: Rating) -> RecordLogItem {
+        if let item = next[grade] { return item }
+        var card = nextDs(t: current.elapsedDays, grade: grade)
+        applyLearningSteps(nextCard: &card, grade: grade, toState: last.state)
+        let item = RecordLogItem(card: card, log: buildLog(rating: grade))
+        next[grade] = item
+        return item
+    }
+
+    override func reviewState(grade: Rating) -> RecordLogItem {
+        if let item = next[grade] { return item }
+        let interval = current.elapsedDays
+
+        var nextAgain = nextDs(t: interval, grade: .again)
+        var nextHard = nextDs(t: interval, grade: .hard)
+        var nextGood = nextDs(t: interval, grade: .good)
+        var nextEasy = nextDs(t: interval, grade: .easy)
+
+        nextIntervalReview(&nextHard, &nextGood, &nextEasy, interval: interval)
+        nextStateReview(&nextHard, &nextGood, &nextEasy)
+        applyLearningSteps(nextCard: &nextAgain, grade: .again, toState: .relearning)
+        nextAgain.lapses += 1
+
+        next[.again] = RecordLogItem(card: nextAgain, log: buildLog(rating: .again))
+        next[.hard] = RecordLogItem(card: nextHard, log: buildLog(rating: .hard))
+        next[.good] = RecordLogItem(card: nextGood, log: buildLog(rating: .good))
+        next[.easy] = RecordLogItem(card: nextEasy, log: buildLog(rating: .easy))
+
+        return next[grade]!
+    }
+
+    private func nextIntervalReview(
+        _ nextHard: inout Card,
+        _ nextGood: inout Card,
+        _ nextEasy: inout Card,
+        interval: Double
+    ) {
+        var hardInterval = algorithm.nextInterval(s: nextHard.stability, elapsedDays: interval)
+        var goodInterval = algorithm.nextInterval(s: nextGood.stability, elapsedDays: interval)
+        hardInterval = min(hardInterval, goodInterval)
+        goodInterval = max(goodInterval, hardInterval + 1)
+        let easyInterval = max(
+            algorithm.nextInterval(s: nextEasy.stability, elapsedDays: interval),
+            goodInterval + 1
+        )
+
+        nextHard.scheduledDays = Double(hardInterval)
+        nextHard.due = Date.dateScheduler(now: reviewTime, t: Double(hardInterval), unit: .days)
+        nextGood.scheduledDays = Double(goodInterval)
+        nextGood.due = Date.dateScheduler(now: reviewTime, t: Double(goodInterval), unit: .days)
+        nextEasy.scheduledDays = Double(easyInterval)
+        nextEasy.due = Date.dateScheduler(now: reviewTime, t: Double(easyInterval), unit: .days)
+    }
+
+    private func nextStateReview(
+        _ nextHard: inout Card,
+        _ nextGood: inout Card,
+        _ nextEasy: inout Card
+    ) {
+        nextHard.state = .review
+        nextHard.learningSteps = 0
+        nextGood.state = .review
+        nextGood.learningSteps = 0
+        nextEasy.state = .review
+        nextEasy.learningSteps = 0
+    }
+}

--- a/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
+++ b/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
@@ -14,8 +14,8 @@ class BasicSchedulerV6: AbstractScheduler {
         grade: Rating,
         fromState state: CardState,
         curStep: Int
-    ) -> (scheduledMinutes: Int, nextStep: Int) {
-        let strategy = basicLearningStepsStrategy(
+    ) throws -> (scheduledMinutes: Int, nextStep: Int) {
+        let strategy = try basicLearningStepsStrategy(
             params: algorithm.parameters,
             state: state,
             curStep: curStep
@@ -31,8 +31,8 @@ class BasicSchedulerV6: AbstractScheduler {
         nextCard: inout Card,
         grade: Rating,
         toState: CardState
-    ) {
-        let info = getStepInfo(
+    ) throws {
+        let info = try getStepInfo(
             grade: grade,
             fromState: current.state,
             curStep: current.learningSteps
@@ -81,7 +81,7 @@ class BasicSchedulerV6: AbstractScheduler {
     override func newState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         var card = try nextDs(t: current.elapsedDays, grade: grade)
-        applyLearningSteps(nextCard: &card, grade: grade, toState: .learning)
+        try applyLearningSteps(nextCard: &card, grade: grade, toState: .learning)
         let item = RecordLogItem(card: card, log: buildLog(rating: grade))
         next[grade] = item
         return item
@@ -90,7 +90,7 @@ class BasicSchedulerV6: AbstractScheduler {
     override func learningState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         var card = try nextDs(t: current.elapsedDays, grade: grade)
-        applyLearningSteps(nextCard: &card, grade: grade, toState: last.state)
+        try applyLearningSteps(nextCard: &card, grade: grade, toState: last.state)
         let item = RecordLogItem(card: card, log: buildLog(rating: grade))
         next[grade] = item
         return item
@@ -107,7 +107,7 @@ class BasicSchedulerV6: AbstractScheduler {
 
         nextIntervalReview(&nextHard, &nextGood, &nextEasy, interval: interval)
         nextStateReview(&nextHard, &nextGood, &nextEasy)
-        applyLearningSteps(nextCard: &nextAgain, grade: .again, toState: .relearning)
+        try applyLearningSteps(nextCard: &nextAgain, grade: .again, toState: .relearning)
         nextAgain.lapses += 1
 
         next[.again] = RecordLogItem(card: nextAgain, log: buildLog(rating: .again))

--- a/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
+++ b/Sources/FSRS/Scheduler/BasicSchedulerV6.swift
@@ -66,47 +66,44 @@ class BasicSchedulerV6: AbstractScheduler {
     /// Compute the next memory state via `algorithm.nextState`. v6's
     /// `nextState` handles the new-card init, manual-rating short-circuit,
     /// short-term path, again-clamp, and recall path internally — keeping
-    /// the scheduler thin.
-    private func nextDs(t: Double, grade: Rating) -> Card {
+    /// the scheduler thin. Propagates `FSRSError(.invalidDeltaT)` /
+    /// `.invalidParam` so callers see invalid clock skew or corrupted card
+    /// state instead of silently scheduling against stale numbers.
+    private func nextDs(t: Double, grade: Rating) throws -> Card {
         var card = current.newCard
-        do {
-            let memoryState = FSRSState(stability: current.stability, difficulty: current.difficulty)
-            let nextState = try algorithm.nextState(memoryState: memoryState, t: t, g: grade)
-            card.difficulty = nextState.difficulty
-            card.stability = nextState.stability
-        } catch {
-            // Defensive: shouldn't trigger for cards routed through this scheduler.
-            print(error.localizedDescription)
-        }
+        let memoryState = FSRSState(stability: current.stability, difficulty: current.difficulty)
+        let nextState = try algorithm.nextState(memoryState: memoryState, t: t, g: grade)
+        card.difficulty = nextState.difficulty
+        card.stability = nextState.stability
         return card
     }
 
-    override func newState(grade: Rating) -> RecordLogItem {
+    override func newState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
-        var card = nextDs(t: current.elapsedDays, grade: grade)
+        var card = try nextDs(t: current.elapsedDays, grade: grade)
         applyLearningSteps(nextCard: &card, grade: grade, toState: .learning)
         let item = RecordLogItem(card: card, log: buildLog(rating: grade))
         next[grade] = item
         return item
     }
 
-    override func learningState(grade: Rating) -> RecordLogItem {
+    override func learningState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
-        var card = nextDs(t: current.elapsedDays, grade: grade)
+        var card = try nextDs(t: current.elapsedDays, grade: grade)
         applyLearningSteps(nextCard: &card, grade: grade, toState: last.state)
         let item = RecordLogItem(card: card, log: buildLog(rating: grade))
         next[grade] = item
         return item
     }
 
-    override func reviewState(grade: Rating) -> RecordLogItem {
+    override func reviewState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         let interval = current.elapsedDays
 
-        var nextAgain = nextDs(t: interval, grade: .again)
-        var nextHard = nextDs(t: interval, grade: .hard)
-        var nextGood = nextDs(t: interval, grade: .good)
-        var nextEasy = nextDs(t: interval, grade: .easy)
+        var nextAgain = try nextDs(t: interval, grade: .again)
+        var nextHard = try nextDs(t: interval, grade: .hard)
+        var nextGood = try nextDs(t: interval, grade: .good)
+        var nextEasy = try nextDs(t: interval, grade: .easy)
 
         nextIntervalReview(&nextHard, &nextGood, &nextEasy, interval: interval)
         nextStateReview(&nextHard, &nextGood, &nextEasy)

--- a/Sources/FSRS/Scheduler/LongTermScheduler.swift
+++ b/Sources/FSRS/Scheduler/LongTermScheduler.swift
@@ -94,7 +94,7 @@ class LongTermScheduler: AbstractScheduler {
     ) {
         nextAgain.difficulty = algorithm.nextDifficulty(d: difficulty, g: .again)
         let sAfterAll = algorithm.nextForgetStability(d: difficulty, s: stability, r: retrievability)
-        nextAgain.stability = FSRSHelper.clamp(stability, FSRSDefaults.S_MIN, sAfterAll)
+        nextAgain.stability = FSRSHelper.clamp(stability, algorithm.sMin, sAfterAll)
         
         nextHard.difficulty = algorithm.nextDifficulty(d: difficulty, g: .hard)
         nextHard.stability = algorithm.nextRecallStability(

--- a/Sources/FSRS/Scheduler/LongTermScheduler.swift
+++ b/Sources/FSRS/Scheduler/LongTermScheduler.swift
@@ -7,7 +7,7 @@
 import Foundation
 
 class LongTermScheduler: AbstractScheduler {
-    override func newState(grade: Rating) -> RecordLogItem {
+    override func newState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         
         current.scheduledDays = 0
@@ -32,11 +32,11 @@ class LongTermScheduler: AbstractScheduler {
         return next[grade]!
     }
     
-    override func learningState(grade: Rating) -> RecordLogItem {
-        reviewState(grade: grade)
+    override func learningState(grade: Rating) throws -> RecordLogItem {
+        try reviewState(grade: grade)
     }
-    
-    override func reviewState(grade: Rating) -> RecordLogItem {
+
+    override func reviewState(grade: Rating) throws -> RecordLogItem {
         if let item = next[grade] { return item }
         
         let interval = current.elapsedDays

--- a/Tests/FSRSTests/FSRSAbstractSchedulerTests.swift
+++ b/Tests/FSRSTests/FSRSAbstractSchedulerTests.swift
@@ -10,11 +10,11 @@ import XCTest
 @testable import FSRS
 
 class BasicSchedulerTests: XCTestCase {
-    func testSymbolIterator() {
+    func testSymbolIterator() throws {
         let now = Date()
         let card = FSRSDefaults().createEmptyCard(now: now)
         let f = FSRS(parameters: .init())
-        let preview = f.repeat(card: card, now: now)
+        let preview = try f.repeat(card: card, now: now)
         let again = try! f.next(card: card, now: now, grade: .again)
         let hard = try! f.next(card: card, now: now, grade: .hard)
         let good = try! f.next(card: card, now: now, grade: .good)

--- a/Tests/FSRSTests/FSRSBasicSchedulerTests.swift
+++ b/Tests/FSRSTests/FSRSBasicSchedulerTests.swift
@@ -21,14 +21,14 @@ class FSRSBasicSchedulerTests: XCTestCase {
         now = Date()
     }
 
-    func testStateNewExist() {
+    func testStateNewExist() throws {
         let card = FSRSDefaults().createEmptyCard(now: now)
         let basicScheduler = BasicScheduler(card: card, reviewTime: now, algorithm: algorithm)
-        let preview = basicScheduler.preview
-        let again = basicScheduler.review(.again)
-        let hard = basicScheduler.review(.hard)
-        let good = basicScheduler.review(.good)
-        let easy = basicScheduler.review(.easy)
+        let preview = try basicScheduler.preview
+        let again = try basicScheduler.review(.again)
+        let hard = try basicScheduler.review(.hard)
+        let good = try basicScheduler.review(.good)
+        let easy = try basicScheduler.review(.easy)
 
         let expectedPreview: [Rating: Card] = [
             .again: again.card,
@@ -44,21 +44,21 @@ class FSRSBasicSchedulerTests: XCTestCase {
         XCTAssertEqual(preview.recordLog[.hard]?.card, expectedPreview[.hard])
 
         for item in preview.recordLog {
-            let expectedCard = basicScheduler.review(item.value.log.rating)
+            let expectedCard = try basicScheduler.review(item.value.log.rating)
             XCTAssertEqual(item.value, expectedCard)
         }
     }
 
-    func testStateLearningExist() {
+    func testStateLearningExist() throws {
         let cardByNew = FSRSDefaults().createEmptyCard(now: now)
-        let card = BasicScheduler(card: cardByNew, reviewTime: now, algorithm: algorithm).review(.again).card
+        let card = try BasicScheduler(card: cardByNew, reviewTime: now, algorithm: algorithm).review(.again).card
         let basicScheduler = BasicScheduler(card: card, reviewTime: now, algorithm: algorithm)
 
-        let preview = basicScheduler.preview
-        let again = basicScheduler.review(.again)
-        let hard = basicScheduler.review(.hard)
-        let good = basicScheduler.review(.good)
-        let easy = basicScheduler.review(.easy)
+        let preview = try basicScheduler.preview
+        let again = try basicScheduler.review(.again)
+        let hard = try basicScheduler.review(.hard)
+        let good = try basicScheduler.review(.good)
+        let easy = try basicScheduler.review(.easy)
 
         let expectedPreview: [Rating: Card] = [
             .again: again.card,
@@ -74,21 +74,21 @@ class FSRSBasicSchedulerTests: XCTestCase {
         XCTAssertEqual(preview.recordLog[.hard]?.card, expectedPreview[.hard])
 
         for item in preview.recordLog {
-            let expectedCard = basicScheduler.review(item.value.log.rating)
+            let expectedCard = try basicScheduler.review(item.value.log.rating)
             XCTAssertEqual(item.value, expectedCard)
         }
     }
 
-    func testStateReviewExist() {
+    func testStateReviewExist() throws {
         let cardByNew = FSRSDefaults().createEmptyCard(now: now)
-        let card = BasicScheduler(card: cardByNew, reviewTime: now, algorithm: algorithm).review(.easy).card
+        let card = try BasicScheduler(card: cardByNew, reviewTime: now, algorithm: algorithm).review(.easy).card
         let basicScheduler = BasicScheduler(card: card, reviewTime: now, algorithm: algorithm)
 
-        let preview = basicScheduler.preview
-        let again = basicScheduler.review(.again)
-        let hard = basicScheduler.review(.hard)
-        let good = basicScheduler.review(.good)
-        let easy = basicScheduler.review(.easy)
+        let preview = try basicScheduler.preview
+        let again = try basicScheduler.review(.again)
+        let hard = try basicScheduler.review(.hard)
+        let good = try basicScheduler.review(.good)
+        let easy = try basicScheduler.review(.easy)
 
         let expectedPreview: [Rating: Card] = [
             .again: again.card,
@@ -104,7 +104,7 @@ class FSRSBasicSchedulerTests: XCTestCase {
         XCTAssertEqual(preview.recordLog[.hard]?.card, expectedPreview[.hard])
 
         for item in preview.recordLog {
-            let expectedCard = basicScheduler.review(item.value.log.rating)
+            let expectedCard = try basicScheduler.review(item.value.log.rating)
             XCTAssertEqual(item.value, expectedCard)
         }
     }

--- a/Tests/FSRSTests/FSRSCodableCompatTests.swift
+++ b/Tests/FSRSTests/FSRSCodableCompatTests.swift
@@ -1,0 +1,105 @@
+//
+//  FSRSCodableCompatTests.swift
+//
+//  Backward-compat: legacy v5 JSON (no `learningSteps` key) must still
+//  decode after the v6 model evolution. These tests guard the
+//  decodeIfPresent strategy in Card / ReviewLog / FSRSParameters.
+//
+
+import XCTest
+@testable import FSRS
+
+final class FSRSCodableCompatTests: XCTestCase {
+
+    private func decoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }
+
+    // MARK: - Card
+
+    func testLegacyCardJSONDecodes() throws {
+        let json = """
+        {
+          "due": "2025-01-01T00:00:00Z",
+          "stability": 1.5,
+          "difficulty": 4.2,
+          "elapsedDays": 0,
+          "scheduledDays": 0,
+          "reps": 0,
+          "lapses": 0,
+          "state": 0
+        }
+        """.data(using: .utf8)!
+
+        let card = try decoder().decode(Card.self, from: json)
+        XCTAssertEqual(card.stability, 1.5)
+        XCTAssertEqual(card.difficulty, 4.2)
+        XCTAssertEqual(card.learningSteps, 0, "Missing learningSteps must default to 0")
+        XCTAssertEqual(card.state, .new)
+    }
+
+    func testCurrentCardJSONRoundTrips() throws {
+        let card = Card(
+            due: Date(timeIntervalSince1970: 1_700_000_000),
+            stability: 2.5,
+            difficulty: 5.0,
+            elapsedDays: 3,
+            scheduledDays: 7,
+            learningSteps: 1,
+            reps: 4,
+            lapses: 1,
+            state: .review,
+            lastReview: Date(timeIntervalSince1970: 1_699_000_000)
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(card)
+        let decoded = try decoder().decode(Card.self, from: data)
+        XCTAssertEqual(card, decoded)
+    }
+
+    // MARK: - ReviewLog
+
+    func testLegacyReviewLogJSONDecodes() throws {
+        let json = """
+        {
+          "rating": 3,
+          "elapsedDays": 1,
+          "lastElapsedDays": 0,
+          "scheduledDays": 4,
+          "review": "2025-01-02T00:00:00Z"
+        }
+        """.data(using: .utf8)!
+
+        let log = try decoder().decode(ReviewLog.self, from: json)
+        XCTAssertEqual(log.rating, .good)
+        XCTAssertEqual(log.learningSteps, 0)
+    }
+
+    // MARK: - FSRSParameters
+
+    func testLegacyParametersJSONDecodes() throws {
+        // Caller stored params from before v6 — no learningSteps/relearningSteps
+        // in the JSON. Should decode using FSRSDefaults values for those.
+        let json = """
+        {
+          "requestRetention": 0.9,
+          "maximumInterval": 36500,
+          "w": [0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575, 0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655, 0.6621],
+          "enableFuzz": false,
+          "enableShortTerm": true
+        }
+        """.data(using: .utf8)!
+
+        let params = try decoder().decode(FSRSParameters.self, from: json)
+        XCTAssertEqual(params.w.count, 19, "Legacy v5 weights preserved")
+        XCTAssertEqual(params.learningSteps, FSRSDefaults.defaultLearningSteps)
+        XCTAssertEqual(params.relearningSteps, FSRSDefaults.defaultRelearningSteps)
+
+        // And v5 path still resolves to v5 algorithm.
+        let f = FSRS(parameters: params)
+        XCTAssertEqual(f.version, .v5)
+    }
+}

--- a/Tests/FSRSTests/FSRSElapsedDaysTests.swift
+++ b/Tests/FSRSTests/FSRSElapsedDaysTests.swift
@@ -23,10 +23,10 @@ class FSRSElapsedDaysTests: XCTestCase {
         card = FSRSDefaults().createEmptyCard(now: createDue)
     }
 
-    func testFirstRepeatGood() {
+    func testFirstRepeatGood() throws {
         var components = DateComponents(year: 2023, month: 11, day: 05, hour: 08, minute: 27, second: 02)
         let firstDue = calendar.date(from: components)! // UTC 2023-11-05 08:27:02.605
-        var sc = f.repeat(card: card, now: firstDue)
+        var sc = try f.repeat(card: card, now: firstDue)
         
         currentLog = sc[.good]?.log
         XCTAssertEqual(currentLog?.elapsedDays, 0)
@@ -37,7 +37,7 @@ class FSRSElapsedDaysTests: XCTestCase {
         let secondDue = calendar.date(from: components)! // UTC 2023-11-08 15:02:09.791
         XCTAssertNotNil(card)
         
-        sc = f.repeat(card: card, now: secondDue)
+        sc = try f.repeat(card: card, now: secondDue)
         currentLog = sc[.again]?.log
         
         var expectedElapsedDays: Double = Date.dateDiff(now: secondDue, pre: card.lastReview, unit: .days)
@@ -50,7 +50,7 @@ class FSRSElapsedDaysTests: XCTestCase {
         let thirdDue = calendar.date(from: components)! // UTC 2023-11-08 15:02:30.799
         XCTAssertNotNil(card)
 
-        sc = f.repeat(card: card, now: thirdDue)
+        sc = try f.repeat(card: card, now: thirdDue)
         currentLog = sc[.again]?.log
         
         expectedElapsedDays = Date.dateDiff(now: thirdDue, pre: card.lastReview, unit: .days)
@@ -63,7 +63,7 @@ class FSRSElapsedDaysTests: XCTestCase {
         let fourthDue = calendar.date(from: components)! // UTC 2023-11-08 15:04:08.739
         XCTAssertNotNil(card)
 
-        sc = f.repeat(card: card, now: fourthDue)
+        sc = try f.repeat(card: card, now: fourthDue)
         currentLog = sc[.good]?.log
         
         expectedElapsedDays = Date.dateDiff(now: fourthDue, pre: card.lastReview, unit: .days)

--- a/Tests/FSRSTests/FSRSForgetTests.swift
+++ b/Tests/FSRSTests/FSRSForgetTests.swift
@@ -29,12 +29,12 @@ class FSRSForgetTests: XCTestCase {
         ))
     }
 
-    func testForget() {
+    func testForget() throws {
         let card = FSRSDefaults().createEmptyCard()
-        
+
         let now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
         let forgetNow = calendar.date(from: DateComponents(year: 2023, month: 12, day: 30, hour: 12, minute: 30))!
-        let schedulingCards = f.repeat(card: card, now: now)
+        let schedulingCards = try f.repeat(card: card, now: now)
 
         let grades: [Rating] = [.again, .hard, .good, .easy]
         

--- a/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
+++ b/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
@@ -1,0 +1,86 @@
+//
+//  FSRSGeneratorParametersV6Tests.swift
+//
+//  Verifies generatorParameters handles 17-, 19-, and 21-length w correctly:
+//  17 → migrates to 19 (legacy v4 → v5, unchanged), 19 stays 19 (v5),
+//  21 stays 21 with v6 clamp ranges. Crucially, 19 does NOT auto-migrate to
+//  21 — that would silently change short-term stability behavior.
+//
+
+import XCTest
+@testable import FSRS
+
+final class FSRSGeneratorParametersV6Tests: XCTestCase {
+
+    func testNoArgsStaysOnV5() {
+        let defaults = FSRSDefaults()
+        let p = defaults.generatorParameters()
+        XCTAssertEqual(p.w.count, 19)
+        XCTAssertEqual(FSRSAlgorithmVersion.detect(p.w), .v5)
+    }
+
+    func testV6DefaultPassesThrough() {
+        let defaults = FSRSDefaults()
+        let p = defaults.generatorParameters(props: .init(w: FSRSDefaults.defaultWv6))
+        XCTAssertEqual(p.w.count, 21)
+        XCTAssertEqual(FSRSAlgorithmVersion.detect(p.w), .v6)
+        // Last weight is the decay default.
+        XCTAssertEqual(p.w[20], FSRSDefaults.FSRS6_DEFAULT_DECAY, accuracy: 1e-9)
+    }
+
+    func testLegacy17PathUnchanged() {
+        // 17-length input still migrates to 19 (v5), as before.
+        let defaults = FSRSDefaults()
+        let raw = Array(repeating: 0.5, count: 17)
+        let p = defaults.generatorParameters(props: .init(w: raw))
+        XCTAssertEqual(p.w.count, 19)
+        XCTAssertEqual(FSRSAlgorithmVersion.detect(p.w), .v5)
+    }
+
+    func test19LengthDoesNotAutoMigrateTo21() {
+        // Legacy v5 weights stay 19 — no silent v6 migration.
+        let defaults = FSRSDefaults()
+        let v5w: [Double] = [
+            0.40255, 1.18385, 3.173, 15.69105, 7.1949, 0.5345, 1.4604, 0.0046, 1.54575,
+            0.1192, 1.01925, 1.9395, 0.11, 0.29605, 2.2698, 0.2315, 2.9898, 0.51655,
+            0.6621,
+        ]
+        let p = defaults.generatorParameters(props: .init(w: v5w))
+        XCTAssertEqual(p.w.count, 19)
+        XCTAssertEqual(p.w, v5w)
+    }
+
+    func testV6ClampForcesValidRanges() {
+        // Out-of-range w[20] should clamp into [0.1, 0.8].
+        let defaults = FSRSDefaults()
+        var w = FSRSDefaults.defaultWv6
+        w[20] = 5.0  // way above 0.8
+        let p = defaults.generatorParameters(props: .init(w: w))
+        XCTAssertEqual(p.w[20], 0.8, accuracy: 1e-9)
+
+        w[20] = -1.0  // below 0.1
+        let p2 = defaults.generatorParameters(props: .init(w: w))
+        XCTAssertEqual(p2.w[20], 0.1, accuracy: 1e-9)
+    }
+
+    func testSMinIsVersionDispatched() {
+        let v5 = FSRS(parameters: .init())
+        XCTAssertEqual(v5.sMin, FSRSDefaults.S_MIN)
+
+        let v6 = FSRS(parameters: .init(w: FSRSDefaults.defaultWv6))
+        XCTAssertEqual(v6.sMin, FSRSDefaults.S_MIN_V6)
+    }
+
+    func testFactorIsDerivedFromDecayInV6() {
+        let v5 = FSRS(parameters: .init())
+        XCTAssertEqual(v5.factor, 19.0 / 81.0, accuracy: 1e-12)
+        XCTAssertEqual(v5.decay, -0.5)
+
+        // v6 with w[20] = 0.5 should produce v5's exact factor (mathematical fixed point).
+        var w = FSRSDefaults.defaultWv6
+        w[20] = 0.5
+        let v6Equivalent = FSRS(parameters: .init(w: w))
+        XCTAssertEqual(v6Equivalent.factor, 19.0 / 81.0, accuracy: 1e-7)
+        XCTAssertEqual(v6Equivalent.decay, -0.5)
+    }
+}

--- a/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
+++ b/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
@@ -71,6 +71,22 @@ final class FSRSGeneratorParametersV6Tests: XCTestCase {
         XCTAssertEqual(v6.sMin, FSRSDefaults.S_MIN_V6)
     }
 
+    func testCeilingFiniteForOutOfRangeInputs() {
+        // w[11] / w[13] feed into log(...) inside computeW17W18Ceiling. Pre-
+        // clamping inputs prevents NaN from a hostile `w` (or a tweaked test
+        // harness) poisoning the rest of the clamp table.
+        var w = FSRSDefaults.defaultWv6
+        w[11] = -1.0   // log(w[11]) would be NaN
+        w[13] = -0.5   // log(2^w[13] - 1) → log(negative) NaN
+        let ceiling = FSRSDefaults.computeW17W18Ceiling(
+            parameters: w,
+            numRelearningSteps: 2
+        )
+        XCTAssertTrue(ceiling.isFinite)
+        XCTAssertGreaterThanOrEqual(ceiling, 0.01)
+        XCTAssertLessThanOrEqual(ceiling, 2.0)
+    }
+
     func testMalformedLearningStepThrowsOnReview() {
         // Malformed step strings used to be silently swallowed by `try?` in
         // basicLearningStepsStrategy, causing the v6 scheduler to graduate

--- a/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
+++ b/Tests/FSRSTests/FSRSGeneratorParametersV6Tests.swift
@@ -71,6 +71,23 @@ final class FSRSGeneratorParametersV6Tests: XCTestCase {
         XCTAssertEqual(v6.sMin, FSRSDefaults.S_MIN_V6)
     }
 
+    func testMalformedLearningStepThrowsOnReview() {
+        // Malformed step strings used to be silently swallowed by `try?` in
+        // basicLearningStepsStrategy, causing the v6 scheduler to graduate
+        // cards immediately. Now they propagate `FSRSError(.invalidParam)`
+        // through the throwing review chain.
+        let p = FSRSParameters(
+            w: FSRSDefaults.defaultWv6,
+            learningSteps: ["1m", "bogus"]
+        )
+        let f = FSRS(parameters: p)
+        let card = FSRSDefaults().createEmptyCard()
+        let now = Date()
+        XCTAssertThrowsError(try f.next(card: card, now: now, grade: .good)) { error in
+            XCTAssertTrue(error is FSRSError, "Expected FSRSError, got \(error)")
+        }
+    }
+
     func testFactorIsDerivedFromDecayInV6() {
         let v5 = FSRS(parameters: .init())
         XCTAssertEqual(v5.factor, 19.0 / 81.0, accuracy: 1e-12)

--- a/Tests/FSRSTests/FSRSLongTermSchedulerTests.swift
+++ b/Tests/FSRSTests/FSRSLongTermSchedulerTests.swift
@@ -31,14 +31,14 @@ class LongTermSchedulerTests: XCTestCase {
     }
 
 
-    func test1() {
+    func test1() throws {
         let testAdditionalCases: (
             _ now: Date,
             _ ratings: [Rating],
             _ exivlHistory: [Int],
             _ exsHistory: [Double],
             _ exdHistory: [Double]
-        ) -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
+        ) throws -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
             guard let self = self else { return }
             var now = now
             var card = FSRSDefaults().createEmptyCard()
@@ -47,7 +47,7 @@ class LongTermSchedulerTests: XCTestCase {
             var dHistory: [Double] = []
 
             for rating in ratings {
-                let record = algorithm.repeat(card: card, now: now)[rating]
+                let record = (try algorithm.repeat(card: card, now: now))[rating]
                 let next = try! FSRS(parameters: params).next(card: card, now: now, grade: rating)
                 XCTAssertEqual(record, next)
 
@@ -62,7 +62,7 @@ class LongTermSchedulerTests: XCTestCase {
             XCTAssertEqual(sHistory, exsHistory)
             XCTAssertEqual(dHistory, exdHistory)
         }
-        testAdditionalCases(
+        try testAdditionalCases(
             calendar.date(from: DateComponents(calendar: Calendar.current, year: 2022, month: 12, day: 29, hour: 12, minute: 30))!,
             [
                 .good, .good, .good, .good, .good, .good, .again,
@@ -83,14 +83,14 @@ class LongTermSchedulerTests: XCTestCase {
             ])
     }
 
-    func test2() {
+    func test2() throws {
         let testAdditionalCases: (
             _ now: Date,
             _ ratings: [Rating],
             _ exivlHistory: [Int],
             _ exsHistory: [Double],
             _ exdHistory: [Double]
-        ) -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
+        ) throws -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
             guard let self = self else { return }
             var now = now
             var card = FSRSDefaults().createEmptyCard()
@@ -99,7 +99,7 @@ class LongTermSchedulerTests: XCTestCase {
             var dHistory: [Double] = []
 
             for rating in ratings {
-                let record = algorithm.repeat(card: card, now: now)[rating]
+                let record = (try algorithm.repeat(card: card, now: now))[rating]
                 let next = try! FSRS(parameters: params).next(card: card, now: now, grade: rating)
                 XCTAssertEqual(record, next)
 
@@ -114,7 +114,7 @@ class LongTermSchedulerTests: XCTestCase {
             XCTAssertEqual(sHistory, exsHistory)
             XCTAssertEqual(dHistory, exdHistory)
         }
-        testAdditionalCases(
+        try testAdditionalCases(
             calendar.date(from: DateComponents(calendar: Calendar.current, year: 2022, month: 12, day: 29, hour: 12, minute: 30))!,
             [
                 .again,
@@ -139,14 +139,14 @@ class LongTermSchedulerTests: XCTestCase {
               ])
     }
 
-    func test3() {
+    func test3() throws {
         let testAdditionalCases: (
             _ now: Date,
             _ ratings: [Rating],
             _ exivlHistory: [Int],
             _ exsHistory: [Double],
             _ exdHistory: [Double]
-        ) -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
+        ) throws -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
             guard let self = self else { return }
             var now = now
             var card = FSRSDefaults().createEmptyCard()
@@ -155,7 +155,7 @@ class LongTermSchedulerTests: XCTestCase {
             var dHistory: [Double] = []
 
             for rating in ratings {
-                let record = algorithm.repeat(card: card, now: now)[rating]
+                let record = (try algorithm.repeat(card: card, now: now))[rating]
                 let next = try! FSRS(parameters: params).next(card: card, now: now, grade: rating)
                 XCTAssertEqual(record, next)
 
@@ -170,7 +170,7 @@ class LongTermSchedulerTests: XCTestCase {
             XCTAssertEqual(sHistory, exsHistory)
             XCTAssertEqual(dHistory, exdHistory)
         }
-        testAdditionalCases(
+        try testAdditionalCases(
             calendar.date(from: DateComponents(calendar: Calendar.current, year: 2022, month: 12, day: 29, hour: 12, minute: 30))!,
             [
                 .hard,
@@ -195,14 +195,14 @@ class LongTermSchedulerTests: XCTestCase {
               ])
     }
 
-    func test4() {
+    func test4() throws {
         let testAdditionalCases: (
             _ now: Date,
             _ ratings: [Rating],
             _ exivlHistory: [Int],
             _ exsHistory: [Double],
             _ exdHistory: [Double]
-        ) -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
+        ) throws -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
             guard let self = self else { return }
             var now = now
             var card = FSRSDefaults().createEmptyCard()
@@ -211,7 +211,7 @@ class LongTermSchedulerTests: XCTestCase {
             var dHistory: [Double] = []
 
             for rating in ratings {
-                let record = algorithm.repeat(card: card, now: now)[rating]
+                let record = (try algorithm.repeat(card: card, now: now))[rating]
                 let next = try! FSRS(parameters: params).next(card: card, now: now, grade: rating)
                 XCTAssertEqual(record, next)
 
@@ -226,7 +226,7 @@ class LongTermSchedulerTests: XCTestCase {
             XCTAssertEqual(sHistory, exsHistory)
             XCTAssertEqual(dHistory, exdHistory)
         }
-        testAdditionalCases(
+        try testAdditionalCases(
             calendar.date(from: DateComponents(calendar: Calendar.current, year: 2022, month: 12, day: 29, hour: 12, minute: 30))!,
             [
                 .good,
@@ -251,14 +251,14 @@ class LongTermSchedulerTests: XCTestCase {
               ])
     }
 
-    func test5() {
+    func test5() throws {
         let testAdditionalCases: (
             _ now: Date,
             _ ratings: [Rating],
             _ exivlHistory: [Int],
             _ exsHistory: [Double],
             _ exdHistory: [Double]
-        ) -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
+        ) throws -> Void = { [weak self] now,ratings,exivlHistory,exsHistory,exdHistory in
             guard let self = self else { return }
             var now = now
             var card = FSRSDefaults().createEmptyCard()
@@ -267,7 +267,7 @@ class LongTermSchedulerTests: XCTestCase {
             var dHistory: [Double] = []
 
             for rating in ratings {
-                let record = algorithm.repeat(card: card, now: now)[rating]
+                let record = (try algorithm.repeat(card: card, now: now))[rating]
                 let next = try! FSRS(parameters: params).next(card: card, now: now, grade: rating)
                 XCTAssertEqual(record, next)
 
@@ -282,7 +282,7 @@ class LongTermSchedulerTests: XCTestCase {
             XCTAssertEqual(sHistory, exsHistory)
             XCTAssertEqual(dHistory, exdHistory)
         }
-        testAdditionalCases(
+        try testAdditionalCases(
             calendar.date(from: DateComponents(calendar: Calendar.current, year: 2022, month: 12, day: 29, hour: 12, minute: 30))!,
             [
                 .easy,
@@ -307,7 +307,7 @@ class LongTermSchedulerTests: XCTestCase {
             ])
     }
 
-    func testStateSwitching() {
+    func testStateSwitching() throws {
         var ivlHistory: [Int] = []
         var sHistory: [Double] = []
         var dHistory: [Double] = []
@@ -325,7 +325,7 @@ class LongTermSchedulerTests: XCTestCase {
             let grade = grades[i]
             let enable = shortTerm[i]
             algorithm.parameters.enableShortTerm = enable
-            let record = algorithm.repeat(card: card, now: now)[grade]
+            let record = (try algorithm.repeat(card: card, now: now))[grade]
             var tempParam = FSRSDefaults().generatorParameters(props: params)
             tempParam.enableShortTerm = enable
             let next = try! FSRS(parameters: tempParam).next(card: card, now: now, grade: grade)
@@ -353,7 +353,7 @@ class LongTermSchedulerTests: XCTestCase {
         ])
     }
 
-    func testGetRetrievability() {
+    func testGetRetrievability() throws {
         let f = FSRS(parameters: .init(w: [
             0.4072, 1.1829, 3.1262, 15.4722, 7.2102, 0.5316, 1.0651, 0.0234, 1.616,
             0.1544, 1.0824, 1.9813, 0.0953, 0.2975, 2.2042, 0.2407, 2.9466, 0.5034,
@@ -362,7 +362,7 @@ class LongTermSchedulerTests: XCTestCase {
         let now = dateFormatter.date(from: "2024-08-03 18:15:34")!
         let viewDate = dateFormatter.date(from: "2024-08-03 18:25:34")!
         var card = FSRSDefaults().createEmptyCard(now: now)
-        card = f.repeat(card: card, now: now)[Rating.again]!.card
+        card = try f.repeat(card: card, now: now)[Rating.again]!.card
         let retrievability = f.getRetrievability(card: card, now: viewDate).string
         XCTAssertEqual(retrievability, "100.00%")
 

--- a/Tests/FSRSTests/FSRSRollbackTests.swift
+++ b/Tests/FSRSTests/FSRSRollbackTests.swift
@@ -24,10 +24,10 @@ class FSRSRollbackTests: XCTestCase {
         ))
     }
 
-    func testFirstRollback() {
+    func testFirstRollback() throws {
         let card = FSRSDefaults().createEmptyCard()
         let now = DateComponents(calendar: .current, year: 2022, month: 12, day: 29, hour: 12, minute: 30).date!
-        let schedulingCards = f.repeat(card: card, now: now)
+        let schedulingCards = try f.repeat(card: card, now: now)
         
         let grades: [Rating] = [Rating.again, Rating.hard, Rating.good, Rating.easy]
         for rating in grades {
@@ -40,14 +40,14 @@ class FSRSRollbackTests: XCTestCase {
         }
     }
 
-    func testRollback2() {
+    func testRollback2() throws {
         var card = FSRSDefaults().createEmptyCard()
         var now = DateComponents(calendar: .current, year: 2022, month: 12, day: 29, hour: 12, minute: 30).date!
-        var schedulingCards = f.repeat(card: card, now: now)
+        var schedulingCards = try f.repeat(card: card, now: now)
 
         card = schedulingCards[Rating.easy]!.card
         now = card.due
-        schedulingCards = f.repeat(card: card, now: now)
+        schedulingCards = try f.repeat(card: card, now: now)
 
         let grades: [Rating] = [Rating.again, Rating.hard, Rating.good, Rating.easy]
         for rating in grades {

--- a/Tests/FSRSTests/FSRSV5Tests.swift
+++ b/Tests/FSRSTests/FSRSV5Tests.swift
@@ -27,10 +27,10 @@ class FSRSV5Tests: XCTestCase {
         f = FSRS(parameters: .init(w: w))
     }
 
-    func testIvlHistory() {
+    func testIvlHistory() throws {
         var card = FSRSDefaults().createEmptyCard()
         var now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
-        var schedulingCards = f.repeat(card: card, now: now)
+        var schedulingCards = try f.repeat(card: card, now: now)
 
         let ratings: [Rating] = [
             .good, .good, .good, .good, .good, .good,
@@ -60,16 +60,16 @@ class FSRSV5Tests: XCTestCase {
             let ivl = card.scheduledDays
             ivlHistory.append(Int(ivl))
             now = card.due
-            schedulingCards = f.repeat(card: card, now: now)
+            schedulingCards = try f.repeat(card: card, now: now)
         }
 
         XCTAssertEqual(ivlHistory, [0, 4, 14, 44, 125, 328, 0, 0, 7, 16, 34, 71, 142,])
     }
 
-    func testMemoryState() {
+    func testMemoryState() throws {
         var card = FSRSDefaults().createEmptyCard()
         var now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
-        var schedulingCards = f.repeat(card: card, now: now)
+        var schedulingCards = try f.repeat(card: card, now: now)
 
         let ratings: [Rating] = [
             .again, .good, .good, .good, .good, .good,
@@ -79,7 +79,7 @@ class FSRSV5Tests: XCTestCase {
         for (index, rating) in ratings.enumerated() {
             card = schedulingCards[rating]!.card
             now.addTimeInterval(Double(intervals[index]) * 24 * 60 * 60) // Adding days as seconds
-            schedulingCards = f.repeat(card: card, now: now)
+            schedulingCards = try f.repeat(card: card, now: now)
         }
 
         let stability = schedulingCards[Rating.good]!.card.stability
@@ -88,10 +88,10 @@ class FSRSV5Tests: XCTestCase {
         XCTAssertEqual(difficulty, 7.0866, accuracy: 0.0001)
     }
 
-    func testFirstRepeat() {
+    func testFirstRepeat() throws {
         let card = FSRSDefaults().createEmptyCard()
         let now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
-        let schedulingCards = f.repeat(card: card, now: now)
+        let schedulingCards = try f.repeat(card: card, now: now)
 
         var stability: [Double] = []
         var difficulty: [Double] = []
@@ -139,9 +139,9 @@ class RetrievabilityTests: XCTestCase {
         XCTAssertEqual(fsrs.getRetrievability(card: card, now: now).string, expected)
     }
 
-    func testRetrievabilityPercentageForReviewCards() {
+    func testRetrievabilityPercentageForReviewCards() throws {
         let card = FSRSDefaults().createEmptyCard(now: dateFormatter.date(from: "2023-12-01 04:00:00")!)
-        let sc = fsrs.repeat(card: card, now: dateFormatter.date(from: "2023-12-01 04:05:00")!)
+        let sc = try fsrs.repeat(card: card, now: dateFormatter.date(from: "2023-12-01 04:05:00")!)
         let expectedResults = ["100.00%", "100.00%", "100.00%", "89.83%"]
         let expectedNumbers = [1.0, 1.0, 1.0, 0.89832125]
 

--- a/Tests/FSRSTests/FSRSV6Tests.swift
+++ b/Tests/FSRSTests/FSRSV6Tests.swift
@@ -1,0 +1,169 @@
+//
+//  FSRSV6Tests.swift
+//
+//  v6 parity tests modeled on ts-fsrs's FSRS-6.test.ts. Oracle values
+//  (intervals, stabilities, difficulties) are taken verbatim from upstream
+//  so the Swift port stays bit-comparable to ts-fsrs.
+//
+
+import XCTest
+@testable import FSRS
+
+final class FSRSV6Tests: XCTestCase {
+    var calendar: Calendar = {
+        var c = Calendar.current
+        c.timeZone = .init(secondsFromGMT: 0)!
+        return c
+    }()
+
+    // Default v6 weights (matches FSRSDefaults.defaultWv6).
+    let w: [Double] = [
+        0.212, 1.2931, 2.3065, 8.2956, 6.4133,
+        0.8334, 3.0194, 0.001, 1.8722, 0.1666,
+        0.796, 1.4835, 0.0614, 0.2629, 1.6483,
+        0.6014, 1.8729, 0.5425, 0.0912, 0.0658,
+        0.1542,
+    ]
+
+    // MARK: - Version detection
+
+    func testVersionDetection() {
+        let v5 = FSRS(parameters: .init())
+        XCTAssertEqual(v5.version, .v5, "Default (no w) is v5")
+
+        let v6 = FSRS(parameters: .init(w: w))
+        XCTAssertEqual(v6.version, .v6, "21-length w is v6")
+
+        XCTAssertEqual(FSRSDefaults.defaultWv6.count, 21)
+    }
+
+    // MARK: - First repeat (matches ts-fsrs FSRS-6.test 'first repeat')
+
+    func testFirstRepeat() {
+        let f = FSRS(parameters: .init(w: w))
+        let card = FSRSDefaults().createEmptyCard()
+        let now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
+        let log = f.repeat(card: card, now: now)
+
+        var stability: [Double] = []
+        var difficulty: [Double] = []
+        var reps: [Int] = []
+        var lapses: [Int] = []
+        var scheduledDays: [Double] = []
+        var states: [CardState] = []
+        for grade in [Rating.again, .hard, .good, .easy] {
+            let c = log[grade]!.card
+            stability.append(c.stability)
+            difficulty.append(c.difficulty)
+            reps.append(c.reps)
+            lapses.append(c.lapses)
+            scheduledDays.append(c.scheduledDays)
+            states.append(c.state)
+        }
+
+        XCTAssertEqual(stability, [0.212, 1.2931, 2.3065, 8.2956])
+        // Difficulty rounded to 8 places per algorithm.toFixedNumber(8).
+        XCTAssertEqual(difficulty[0], 6.4133, accuracy: 1e-7)
+        XCTAssertEqual(difficulty[1], 5.11217071, accuracy: 1e-7)
+        XCTAssertEqual(difficulty[2], 2.11810397, accuracy: 1e-7)
+        XCTAssertEqual(difficulty[3], 1.0, accuracy: 1e-7)
+        XCTAssertEqual(reps, [1, 1, 1, 1])
+        XCTAssertEqual(lapses, [0, 0, 0, 0])
+        XCTAssertEqual(scheduledDays, [0, 0, 0, 8])
+        XCTAssertEqual(states, [.learning, .learning, .learning, .review])
+    }
+
+    // MARK: - Interval history (matches ts-fsrs FSRS-6.test 'ivl_history')
+
+    func testIvlHistory() throws {
+        let f = FSRS(parameters: .init(w: w))
+        var card = FSRSDefaults().createEmptyCard()
+        var now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
+        var schedulingCards = f.repeat(card: card, now: now)
+
+        let ratings: [Rating] = [
+            .good, .good, .good, .good, .good, .good,
+            .again, .again, .good, .good, .good, .good, .good,
+        ]
+
+        var ivlHistory: [Int] = []
+        for rating in ratings {
+            // Cross-check: rollback round-trips, and `next(...)` agrees with `repeat(...)[grade]`.
+            for check in [Rating.again, .hard, .good, .easy] {
+                let rollback = try f.rollback(
+                    card: schedulingCards[check]!.card,
+                    log: schedulingCards[check]!.log
+                )
+                XCTAssertEqual(rollback, card)
+
+                let elapsed = card.lastReview != nil
+                    ? Date.dateDiff(now: now, pre: card.lastReview, unit: .days)
+                    : 0
+                XCTAssertEqual(schedulingCards[check]!.log.elapsedDays, elapsed)
+
+                let tempF = FSRS(parameters: .init(w: w))
+                let next = try tempF.next(card: card, now: now, grade: check)
+                XCTAssertEqual(schedulingCards[check], next)
+            }
+
+            card = schedulingCards[rating]!.card
+            ivlHistory.append(Int(card.scheduledDays))
+            now = card.due
+            schedulingCards = f.repeat(card: card, now: now)
+        }
+
+        XCTAssertEqual(ivlHistory, [0, 2, 11, 46, 163, 498, 0, 0, 2, 4, 7, 12, 21])
+    }
+
+    // MARK: - Memory state oracles
+
+    private func runMemoryStateSequence(enableShortTerm: Bool) throws -> Card {
+        let f = FSRS(parameters: .init(w: w, enableShortTerm: enableShortTerm))
+        var card = FSRSDefaults().createEmptyCard()
+        var now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
+        let ratings: [Rating] = [.again, .good, .good, .good, .good, .good]
+        let intervals: [Double] = [0, 0, 1, 3, 8, 21]
+
+        for (i, rating) in ratings.enumerated() {
+            now = Date(timeIntervalSince1970: now.timeIntervalSince1970 + intervals[i] * 86400)
+            card = try f.next(card: card, now: now, grade: rating).card
+        }
+        return card
+    }
+
+    func testMemoryStateShortTerm() throws {
+        let card = try runMemoryStateSequence(enableShortTerm: true)
+        XCTAssertEqual(card.stability, 53.62691, accuracy: 1e-4)
+        XCTAssertEqual(card.difficulty, 6.3574867, accuracy: 1e-4)
+    }
+
+    func testMemoryStateLongTerm() throws {
+        let card = try runMemoryStateSequence(enableShortTerm: false)
+        XCTAssertEqual(card.stability, 53.335106, accuracy: 1e-4)
+        XCTAssertEqual(card.difficulty, 6.3574867, accuracy: 1e-4)
+    }
+
+    // MARK: - Forgetting curve uses learnable decay
+
+    func testForgettingCurveUsesLearnableDecay() {
+        // Both versions cross R=0.9 at t=s by construction. The shapes differ:
+        // v6's smaller |decay| gives a flatter curve — at t > s, v6 retains
+        // *more* than v5 (longer tail). At t < s, v6 forgets faster.
+        let v5 = FSRS(parameters: .init())
+        let v6 = FSRS(parameters: .init(w: w))
+
+        XCTAssertEqual(v5.forgettingCurve(elapsedDays: 1, stability: 1), 0.9, accuracy: 1e-7)
+        XCTAssertEqual(v6.forgettingCurve(elapsedDays: 1, stability: 1), 0.9, accuracy: 1e-4)
+
+        // 10 days into a stability-1 card: v6's flatter tail keeps R higher.
+        XCTAssertGreaterThan(
+            v6.forgettingCurve(elapsedDays: 10, stability: 1),
+            v5.forgettingCurve(elapsedDays: 10, stability: 1)
+        )
+
+        // Different decays imply different factors.
+        XCTAssertNotEqual(v5.factor, v6.factor)
+        XCTAssertEqual(v5.decay, -0.5)
+        XCTAssertEqual(v6.decay, -0.1542)
+    }
+}

--- a/Tests/FSRSTests/FSRSV6Tests.swift
+++ b/Tests/FSRSTests/FSRSV6Tests.swift
@@ -39,11 +39,11 @@ final class FSRSV6Tests: XCTestCase {
 
     // MARK: - First repeat (matches ts-fsrs FSRS-6.test 'first repeat')
 
-    func testFirstRepeat() {
+    func testFirstRepeat() throws {
         let f = FSRS(parameters: .init(w: w))
         let card = FSRSDefaults().createEmptyCard()
         let now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
-        let log = f.repeat(card: card, now: now)
+        let log = try f.repeat(card: card, now: now)
 
         var stability: [Double] = []
         var difficulty: [Double] = []
@@ -79,7 +79,7 @@ final class FSRSV6Tests: XCTestCase {
         let f = FSRS(parameters: .init(w: w))
         var card = FSRSDefaults().createEmptyCard()
         var now = calendar.date(from: DateComponents(year: 2022, month: 12, day: 29, hour: 12, minute: 30))!
-        var schedulingCards = f.repeat(card: card, now: now)
+        var schedulingCards = try f.repeat(card: card, now: now)
 
         let ratings: [Rating] = [
             .good, .good, .good, .good, .good, .good,
@@ -109,7 +109,7 @@ final class FSRSV6Tests: XCTestCase {
             card = schedulingCards[rating]!.card
             ivlHistory.append(Int(card.scheduledDays))
             now = card.due
-            schedulingCards = f.repeat(card: card, now: now)
+            schedulingCards = try f.repeat(card: card, now: now)
         }
 
         XCTAssertEqual(ivlHistory, [0, 2, 11, 46, 163, 498, 0, 0, 2, 4, 7, 12, 21])


### PR DESCRIPTION
## Summary

Adds FSRS-6.0 support alongside the existing FSRS-5.0 implementation. **v5 remains the default** — a no-arg `FSRS()` is byte-identical to today. v6 is opt-in via a 21-length `w` (e.g. `FSRSDefaults.defaultWv6`). Mirrors upstream [ts-fsrs](https://github.com/open-spaced-repetition/ts-fsrs).

## What's new

- **Learnable decay & factor** — `decay = -w[20]`, `factor = exp(ln(0.9)/decay) - 1`. v5's `-0.5`/`19/81` is the mathematical fixed point at `w[20]=0.5`.
- **New short-term stability formula** — adds `s^-w[19]` factor and a Hard/Easy floor (`max(sinc, 1.0)`).
- **`S_MIN` lowered to `0.001`** for v6 (v5 keeps `0.01`).
- **Configurable learning steps** — `FSRSParameters.learningSteps` / `relearningSteps` accept strings like `"1m"`, `"10m"`, `"1h"`, `"1d"`. Default `["1m","10m"]` and `["10m"]`.
- **`BasicSchedulerV6`** — new scheduler delegating state transitions to `algorithm.nextState`, applying steps with a 1440-min day cutoff. Used only when `version == .v6 && enableShortTerm`. Existing `BasicScheduler` remains the v5 path, untouched.

## Opt-in usage

```swift
let v5 = FSRS(parameters: .init())                           // unchanged
let v6 = FSRS(parameters: .init(w: FSRSDefaults.defaultWv6)) // FSRS-6.0
```

## ⚠️ Breaking changes

Addressing Copilot's review: the v6 scheduler used to swallow `FSRSError(.invalidDeltaT)` / `.invalidParam` from `algorithm.nextState` (`print` + continue with stale stability/difficulty), and `basicLearningStepsStrategy` silently graduated cards on a malformed step string (`try?` → `[:]`). Both were silent-failure paths that let invalid input change scheduling without notice.

Fixed by threading `throws` through the scheduler review chain:

| Symbol | Before | After |
|---|---|---|
| `FSRS.repeat(card:now:_:)` | `-> IPreview` | `throws -> IPreview` |
| `IScheduler.review(_:)` | `-> RecordLogItem` | `throws -> RecordLogItem` |
| `IScheduler.preview` | `{ get }` | `{ get throws }` |
| `basicLearningStepsStrategy` | non-throwing | `throws` |

`FSRS.next(...)` was already `throws` — no signature change there, but it now propagates v6 errors instead of silently consuming them.

**Caller migration** (`v` → `v?`):

```diff
- let log = f.repeat(card: card, now: now)
+ let log = try f.repeat(card: card, now: now)
```

v5 schedulers (`BasicScheduler`, `LongTermScheduler`) gain `throws` markers but never actually throw at runtime, so v5 bit-exactness is preserved.

## Backward compatibility

- `FSRSV5Tests` passes bit-exact at every commit boundary.
- 19-length `w` is **never** auto-migrated to v6 — that would silently change short-term stability behavior (the new Hard/Easy floor has no v5 equivalent). Migration is explicit.
- Legacy JSON for `Card` / `ReviewLog` / `FSRSParameters` (no `learningSteps` keys) decodes via hand-written `init(from:)` using `decodeIfPresent`. Verified by `FSRSCodableCompatTests`.
- `LongTermScheduler` is shared across versions — the short-term-disabled path collapses `w[17]*w[18]` to 0, so v5 and v6 formulas converge once `sMin` is threaded through.
- `rollback` now restores `learningSteps` from the log (latent v5 bug — unobservable because v5 always had `learningSteps == 0`).

## Review-feedback fixes (Copilot)

- Throws cascade through the scheduler chain (above).
- `basicLearningStepsStrategy` throws on malformed step strings instead of returning `[:]` and graduating cards.
- `computeW17W18Ceiling` pre-clamps `w[11]` / `w[13]` / `w[14]` before `log(...)` so out-of-range inputs can't NaN-poison the ceiling and the rest of the clamp table.
- Dropped unused `inputCount` local in `generatorParameters`.
- Reworded `learningSteps` doc on `Card` and `ReviewLog` — it's a 0-based step index, only meaningful when `state` is `.learning` / `.relearning`.
- Removed unused `FSRS5_DEFAULT_DECAY` constant (no migration helper exists yet).

## Test plan

- [x] `swift test` — 68 passed (was 66 before review fixes; 49 before the PR)
- [x] v6 oracles match ts-fsrs `FSRS-6.test.ts` byte-for-byte:
  - `ivl_history` = `[0, 2, 11, 46, 163, 498, 0, 0, 2, 4, 7, 12, 21]`
  - short-term memory state = `(53.62691, 6.3574867)`
  - long-term memory state = `(53.335106, 6.3574867)`
  - first-repeat stability/difficulty/state arrays
- [x] `FSRSV5Tests` unchanged and passing
- [x] Legacy v5 JSON decodes with `learningSteps = 0`
- [x] 17→19 (legacy v4) generator path unchanged; 19 stays v5; 21 stays v6
- [x] Malformed `learningSteps` (e.g. `"bogus"`) throws `FSRSError(.invalidParam)` from `f.next(...)`
- [x] `computeW17W18Ceiling` returns finite value within `[0.01, 2.0]` for hostile `w[11]` / `w[13]`